### PR TITLE
Trying to make this usable as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+#![feature(unsafe_destructor)]
+
+extern crate serialize;
+extern crate core;
+
+pub mod networking;
+pub mod serialization;
+pub mod progress;
+pub mod example;
+pub mod communication;
+

--- a/src/progress/broadcast.rs
+++ b/src/progress/broadcast.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::{Sender, Receiver};
 use progress::Timestamp;
 use communication::ChannelAllocator;
 
-type ProgressVec<T> = Vec<(u64, u64, T, i64)>;  // (scope, [in/out]port, timestamp, delta)
+pub type ProgressVec<T> = Vec<(u64, u64, T, i64)>;  // (scope, [in/out]port, timestamp, delta)
 
 // a mechanism for broadcasting progress information within a scope
 // broadcasts contents of update, repopulates from broadcasts


### PR DESCRIPTION
With the changes below, it becomes possible to use timely as a library, for example in [this little program](https://gist.github.com/zerebubuth/00e022087a3fc3ede855) based on an extract of timely's `src/main.rs`. However, I'm not entirely sure that it's working properly, as the example seems to loop endlessly?