### PR TITLE
Made Scope implementations take slices instead of vectors when applicabl...

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,18 @@ pub trait Scope<T: Timestamp, S: PathSummary<T>>
 
     // 1b. receives (output -> input) summaries, and initial messages capabilities on inputs.
     fn set_external_summary(&mut self, summaries: Vec<Vec<Antichain<S>>>,
-                                       frontier: &Vec<Vec<(T, i64)>>) -> ();
+                                       frontier: &[Vec<(T, i64)>]) -> ();
 
     // 2a. receives changes in the message capabilities from the external graph.
-    fn push_external_progress(&mut self, external_progress: &Vec<Vec<(T, i64)>>) -> ();
+    fn push_external_progress(&mut self, external_progress: &[Vec<(T, i64)>]) -> ();
 
     // 2b. describing changes internal to the scope, specifically:
     //      * changes to messages capabilities for each output,
     //      * number of messages consumed on each input,
     //      * number of messages produced on each output.
-    fn pull_internal_progress(&mut self, internal_progress: &mut Vec<Vec<(T, i64)>>,
-                                         messages_consumed: &mut Vec<Vec<(T, i64)>>,
-                                         messages_produced: &mut Vec<Vec<(T, i64)>>) -> ();
+    fn pull_internal_progress(&mut self, internal_progress: &mut [Vec<(T, i64)>],
+                                         messages_consumed: &mut [Vec<(T, i64)>],
+                                         messages_produced: &mut [Vec<(T, i64)>]) -> ();
 }
 ```
 

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -67,12 +67,12 @@ fn _barrier<C: Communicator>(communicator: C, bencher: Option<&mut Bencher>) {
 
     // start things up!
     graph.0.borrow_mut().get_internal_summary();
-    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut Vec::new());
-    graph.0.borrow_mut().push_external_progress(&mut Vec::new());
+    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut []);
+    graph.0.borrow_mut().push_external_progress(&mut []);
 
     // spin
     match bencher {
-        Some(b) => b.iter(|| { graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()); }),
-        None    => while graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()) { },
+        Some(b) => b.iter(|| { graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []); }),
+        None    => while graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []) { },
     }
 }

--- a/examples/distinct.rs
+++ b/examples/distinct.rs
@@ -73,18 +73,18 @@ fn _distinct<C: Communicator>(communicator: C) {
 
     // finalize the graph/subgraph
     graph.0.borrow_mut().get_internal_summary();
-    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut Vec::new());
+    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut []);
 
     // do one round of push progress, pull progress ...
-    graph.0.borrow_mut().push_external_progress(&mut Vec::new());
-    graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new());
+    graph.0.borrow_mut().push_external_progress(&mut []);
+    graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []);
 
     // move some data into the dataflow graph.
     input1.send_messages(&Product::new((), 0), vec![1u64]);
     input2.send_messages(&Product::new((), 0), vec![2u64]);
 
     // see what everyone thinks about that ...
-    graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new());
+    graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []);
 
     input1.advance(&Product::new((), 0), &Product::new((), 1000000));
     input2.advance(&Product::new((), 0), &Product::new((), 1000000));
@@ -92,7 +92,7 @@ fn _distinct<C: Communicator>(communicator: C) {
     input2.close_at(&Product::new((), 1000000));
 
     // spin
-    while graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()) { }
+    while graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []) { }
 }
 
 fn _create_subgraph<G: Graph, D: Data+Hash+Eq+Debug+Columnar>(graph: &mut G, source1: &mut Stream<G, D>, source2: &mut Stream<G, D>) -> (Stream<G, D>, Stream<G, D>) {

--- a/src/example/barrier.rs
+++ b/src/example/barrier.rs
@@ -21,7 +21,7 @@ impl Scope<Product<(), u64>> for BarrierScope {
                 vec![CountMap::new_from(&Product::new((), self.epoch), self.degree as i64)]);
     }
 
-    fn push_external_progress(&mut self, external: &mut Vec<CountMap<Product<(), u64>>>) -> () {
+    fn push_external_progress(&mut self, external: &mut [CountMap<Product<(), u64>>]) -> () {
         while let Some((time, val)) = external[0].pop() {
             if time.inner == self.epoch - 1 && val == -1 {
                 self.ready = true;
@@ -29,9 +29,9 @@ impl Scope<Product<(), u64>> for BarrierScope {
         }
     }
 
-    fn pull_internal_progress(&mut self, internal: &mut Vec<CountMap<Product<(), u64>>>,
-                                        _consumed: &mut Vec<CountMap<Product<(), u64>>>,
-                                        _produced: &mut Vec<CountMap<Product<(), u64>>>) -> bool {
+    fn pull_internal_progress(&mut self, internal: &mut [CountMap<Product<(), u64>>],
+                                        _consumed: &mut [CountMap<Product<(), u64>>],
+                                        _produced: &mut [CountMap<Product<(), u64>>]) -> bool {
         if self.ready {
             internal[0].update(&Product::new((), self.epoch), -1);
 

--- a/src/example/command.rs
+++ b/src/example/command.rs
@@ -103,7 +103,7 @@ impl Scope<((), u64)> for CommandScope {
         (vec![vec![Antichain::from_elem(Default::default())]], internal)
     }
 
-    fn push_external_progress(&mut self, external: &mut Vec<CountMap<((), u64)>>) -> () {
+    fn push_external_progress(&mut self, external: &mut [CountMap<((), u64)>]) -> () {
         let mut writer = MemWriter::new();
         for index in (0..external.len()) {
             writer.write_le_uint(external[index].len()).ok().expect("a");
@@ -125,9 +125,9 @@ impl Scope<((), u64)> for CommandScope {
         stdin.flush().ok().expect("flush failure");
     }
 
-    fn pull_internal_progress(&mut self,  internal: &mut Vec<CountMap<((), u64)>>,
-                                          consumed: &mut Vec<CountMap<((), u64)>>,
-                                          produced: &mut Vec<CountMap<((), u64)>>) -> bool
+    fn pull_internal_progress(&mut self,  internal: &mut [CountMap<((), u64)>],
+                                          consumed: &mut [CountMap<((), u64)>],
+                                          produced: &mut [CountMap<((), u64)>]) -> bool
     {
         let stdout = (&mut self.process.stdout).as_mut().unwrap();
 

--- a/src/example/concat.rs
+++ b/src/example/concat.rs
@@ -55,9 +55,9 @@ impl<T:Timestamp> Scope<T> for ConcatScope<T> where <T as Columnar>::Stack: 'sta
     fn inputs(&self) -> u64 { self.consumed.len() as u64 }
     fn outputs(&self) -> u64 { 1 }
 
-    fn pull_internal_progress(&mut self, _frontier_progress: &mut Vec<CountMap<T>>,
-                                          messages_consumed: &mut Vec<CountMap<T>>,
-                                          messages_produced: &mut Vec<CountMap<T>>) -> bool
+    fn pull_internal_progress(&mut self, _frontier_progress: &mut [CountMap<T>],
+                                          messages_consumed: &mut [CountMap<T>],
+                                          messages_produced: &mut [CountMap<T>]) -> bool
     {
         for (index, updates) in self.consumed.iter().enumerate() {
             while let Some((key, val)) = updates.borrow_mut().pop() {

--- a/src/example/feedback.rs
+++ b/src/example/feedback.rs
@@ -103,9 +103,9 @@ impl<T:Timestamp> Scope<T> for FeedbackScope<T> {
         (vec![vec![Antichain::from_elem(self.summary)]], vec![CountMap::new()])
     }
 
-    fn pull_internal_progress(&mut self, _frontier_progress: &mut Vec<CountMap<T>>,
-                                          messages_consumed: &mut Vec<CountMap<T>>,
-                                          messages_produced: &mut Vec<CountMap<T>>) -> bool {
+    fn pull_internal_progress(&mut self, _frontier_progress: &mut [CountMap<T>],
+                                          messages_consumed: &mut [CountMap<T>],
+                                          messages_produced: &mut [CountMap<T>]) -> bool {
 
         self.consumed_messages.borrow_mut().drain_into(&mut messages_consumed[0]);
         self.produced_messages.borrow_mut().drain_into(&mut messages_produced[0]);

--- a/src/example/input.rs
+++ b/src/example/input.rs
@@ -64,9 +64,9 @@ impl<T:Timestamp> Scope<T> for InputScope<T> {
         (Vec::new(), vec![map])
     }
 
-    fn pull_internal_progress(&mut self, frontier_progress: &mut Vec<CountMap<T>>,
-                                        _messages_consumed: &mut Vec<CountMap<T>>,
-                                         messages_produced: &mut Vec<CountMap<T>>) -> bool
+    fn pull_internal_progress(&mut self, frontier_progress: &mut [CountMap<T>],
+                                        _messages_consumed: &mut [CountMap<T>],
+                                         messages_produced: &mut [CountMap<T>]) -> bool
     {
         self.messages.borrow_mut().drain_into(&mut messages_produced[0]);
         self.progress.borrow_mut().drain_into(&mut frontier_progress[0]);

--- a/src/example/partition.rs
+++ b/src/example/partition.rs
@@ -58,9 +58,9 @@ impl<T:Timestamp, D: Data, F: Fn(&D)->u64, P: Pullable<(T, Vec<D>)>> Scope<T> fo
     fn inputs(&self) -> u64 { 1 }
     fn outputs(&self) -> u64 { self.outputs.len() as u64 }
 
-    fn pull_internal_progress(&mut self,_internal: &mut Vec<CountMap<T>>,
-                                         consumed: &mut Vec<CountMap<T>>,
-                                         produced: &mut Vec<CountMap<T>>) -> bool {
+    fn pull_internal_progress(&mut self,_internal: &mut [CountMap<T>],
+                                         consumed: &mut [CountMap<T>],
+                                         produced: &mut [CountMap<T>]) -> bool {
 
         while let Some((time, data)) = self.input.pull() {
             let outputs = self.outputs.iter_mut();

--- a/src/example/unary.rs
+++ b/src/example/unary.rs
@@ -101,19 +101,19 @@ where T: Timestamp,
     fn inputs(&self) -> u64 { 1 }
     fn outputs(&self) -> u64 { 1 }
 
-    fn set_external_summary(&mut self, _summaries: Vec<Vec<Antichain<T::Summary>>>, frontier: &mut Vec<CountMap<T>>) -> () {
+    fn set_external_summary(&mut self, _summaries: Vec<Vec<Antichain<T::Summary>>>, frontier: &mut [CountMap<T>]) -> () {
         self.handle.notificator.update_frontier_from_cm(frontier);
         frontier[0].clear();
     }
 
-    fn push_external_progress(&mut self, external: &mut Vec<CountMap<T>>) -> () {
+    fn push_external_progress(&mut self, external: &mut [CountMap<T>]) -> () {
         self.handle.notificator.update_frontier_from_cm(external);
         external[0].clear();
     }
 
-    fn pull_internal_progress(&mut self, internal: &mut Vec<CountMap<T>>,
-                                         consumed: &mut Vec<CountMap<T>>,
-                                         produced: &mut Vec<CountMap<T>>) -> bool
+    fn pull_internal_progress(&mut self, internal: &mut [CountMap<T>],
+                                         consumed: &mut [CountMap<T>],
+                                         produced: &mut [CountMap<T>]) -> bool
     {
         (self.logic)(&mut self.handle);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,18 +169,18 @@ fn _distinct<C: Communicator>(communicator: C, bencher: Option<&mut Bencher>) {
 
     // finalize the graph/subgraph
     graph.0.borrow_mut().get_internal_summary();
-    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut Vec::new());
+    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut []);
 
     // do one round of push progress, pull progress ...
-    graph.0.borrow_mut().push_external_progress(&mut Vec::new());
-    graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new());
+    graph.0.borrow_mut().push_external_progress(&mut []);
+    graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []);
 
     // move some data into the dataflow graph.
     input1.send_messages(&Product::new((), 0), vec![1u64]);
     input2.send_messages(&Product::new((), 0), vec![2u64]);
 
     // see what everyone thinks about that ...
-    graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new());
+    graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []);
 
     input1.advance(&Product::new((), 0), &Product::new((), 1000000));
     input2.advance(&Product::new((), 0), &Product::new((), 1000000));
@@ -189,8 +189,8 @@ fn _distinct<C: Communicator>(communicator: C, bencher: Option<&mut Bencher>) {
 
     // spin
     match bencher {
-        Some(b) => b.iter(|| { graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()); }),
-        None    => while graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()) { }
+        Some(b) => b.iter(|| { graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []); }),
+        None    => while graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []) { }
     }
 }
 
@@ -208,15 +208,15 @@ fn _distinct<C: Communicator>(communicator: C, bencher: Option<&mut Bencher>) {
 //
 //     // start things up!
 //     graph.borrow_mut().get_internal_summary();
-//     graph.borrow_mut().set_external_summary(Vec::new(), &mut Vec::new());
-//     graph.borrow_mut().push_external_progress(&mut Vec::new());
+//     graph.borrow_mut().set_external_summary(Vec::new(), &mut []);
+//     graph.borrow_mut().push_external_progress(&mut []);
 //
 //     input.0.close_at(&((), 0));
 //
 //     // spin
 //     match bencher {
-//         Some(b) => b.iter(|| { graph.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()); }),
-//         None    => while graph.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()) { },
+//         Some(b) => b.iter(|| { graph.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []); }),
+//         None    => while graph.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []) { },
 //     }
 // }
 
@@ -230,12 +230,12 @@ fn _barrier<C: Communicator>(communicator: C, bencher: Option<&mut Bencher>) {
 
     // start things up!
     graph.0.borrow_mut().get_internal_summary();
-    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut Vec::new());
-    graph.0.borrow_mut().push_external_progress(&mut Vec::new());
+    graph.0.borrow_mut().set_external_summary(Vec::new(), &mut []);
+    graph.0.borrow_mut().push_external_progress(&mut []);
 
     // spin
     match bencher {
-        Some(b) => b.iter(|| { graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()); }),
-        None    => while graph.0.borrow_mut().pull_internal_progress(&mut Vec::new(), &mut Vec::new(), &mut Vec::new()) { },
+        Some(b) => b.iter(|| { graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []); }),
+        None    => while graph.0.borrow_mut().pull_internal_progress(&mut [], &mut [], &mut []) { },
     }
 }

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -143,7 +143,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Scope<TOuter> for Subgraph<TOuter, TI
     }
 
     // receives (out -> in) summaries using only edges external to the vertex.
-    fn set_external_summary(&mut self, summaries: Vec<Vec<Antichain<TOuter::Summary>>>, frontier: &mut Vec<CountMap<TOuter>>) -> () {
+    fn set_external_summary(&mut self, summaries: Vec<Vec<Antichain<TOuter::Summary>>>, frontier: &mut [CountMap<TOuter>]) -> () {
         self.external_summaries = summaries;
         self.set_summaries();
 
@@ -203,7 +203,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Scope<TOuter> for Subgraph<TOuter, TI
 
     // information for the scope about progress in the outside world (updates to the input frontiers)
     // important to push this information on to subscopes.
-    fn push_external_progress(&mut self, external_progress: &mut Vec<CountMap<TOuter>>) -> () {
+    fn push_external_progress(&mut self, external_progress: &mut [CountMap<TOuter>]) -> () {
         // transform into pointstamps to use push_progress_to_target().
         for (input, progress) in external_progress.iter_mut().enumerate() {
             while let Some((time, val)) = progress.pop() {
@@ -222,9 +222,9 @@ impl<TOuter: Timestamp, TInner: Timestamp> Scope<TOuter> for Subgraph<TOuter, TI
     }
 
     // information from the vertex about its progress (updates to the output frontiers, recv'd and sent message counts)
-    fn pull_internal_progress(&mut self, internal_progress: &mut Vec<CountMap<TOuter>>,
-                                         messages_consumed: &mut Vec<CountMap<TOuter>>,
-                                         messages_produced: &mut Vec<CountMap<TOuter>>) -> bool {
+    fn pull_internal_progress(&mut self, internal_progress: &mut [CountMap<TOuter>],
+                                         messages_consumed: &mut [CountMap<TOuter>],
+                                         messages_produced: &mut [CountMap<TOuter>]) -> bool {
         // should be false when there is nothing left to do
         let mut active = false;
 

--- a/src/progress/notificator.rs
+++ b/src/progress/notificator.rs
@@ -12,7 +12,7 @@ pub struct Notificator<T: Timestamp> {
 }
 
 impl<T: Timestamp> Notificator<T> {
-    pub fn update_frontier_from_cm(&mut self, count_map: &mut Vec<CountMap<T>>) {
+    pub fn update_frontier_from_cm(&mut self, count_map: &mut [CountMap<T>]) {
         for index in 0..count_map.len() {
             while self.frontier.len() < count_map.len() {
                 self.frontier.push(MutableAntichain::new());

--- a/src/progress/scope.rs
+++ b/src/progress/scope.rs
@@ -15,20 +15,20 @@ pub trait Scope<T: Timestamp> {
 
     // Reports (out -> in) summaries for the vertex, and initial frontier information.
     // TODO: Update this to be summaries along paths external to the vertex, as this is strictly more informative.
-    fn set_external_summary(&mut self, _summaries: Vec<Vec<Antichain<T::Summary>>>, _frontier: &mut Vec<CountMap<T>>) -> () { }
+    fn set_external_summary(&mut self, _summaries: Vec<Vec<Antichain<T::Summary>>>, _frontier: &mut [CountMap<T>]) -> () { }
 
     // Reports changes to the projection of external work onto each of the scope's inputs.
     // TODO: Update this to be strictly external work, i.e. not work from this vertex.
     // Note: callee is expected to consume the contents of _external to indicate acknowledgement.
-    fn push_external_progress(&mut self, _external: &mut Vec<CountMap<T>>) -> () { }
+    fn push_external_progress(&mut self, _external: &mut [CountMap<T>]) -> () { }
 
     // Requests changes to the projection of internal work onto each of the scope's outputs, and
     //          changes to the number of messages consumed by each of the scope's inputs, and
     //          changes to the number of messages producen on each of the scope's outputs.
     // Returns a bool indicating if there is any un-reported work remaining (e.g. work that doesn't project on an output).
-    fn pull_internal_progress(&mut self,  internal: &mut Vec<CountMap<T>>,           // to populate
-                                          consumed: &mut Vec<CountMap<T>>,           // to populate
-                                          produced: &mut Vec<CountMap<T>>) -> bool;  // to populate
+    fn pull_internal_progress(&mut self,  internal: &mut [CountMap<T>],           // to populate
+                                          consumed: &mut [CountMap<T>],           // to populate
+                                          produced: &mut [CountMap<T>]) -> bool;  // to populate
 
     fn name(&self) -> String;               // something descriptive and helpful.
     fn notify_me(&self) -> bool { true }    // override to false if no interest in push_external_progress().


### PR DESCRIPTION
...e. Previously, the implementations were just expected to avoid deleting any inputs or changing the length of the vectors - this is now enforced by the types.