### PR TITLE
Stop cloning Communicators and use mutable references instead of Rc.

### DIFF
--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -1,6 +1,7 @@
 #![feature(core)]
 #![feature(test)]
 #![feature(unsafe_destructor)]
+#![feature(scoped)]
 
 /* Based on src/main.rs from timely-dataflow by Frank McSherry,
 *

--- a/examples/distinct.rs
+++ b/examples/distinct.rs
@@ -107,22 +107,26 @@ fn _create_subgraph<'a, 'b, G, D>(graph: &'a RefCell<&'b mut G>,
                                                                           Stream<'a, 'b, G, D>)
 where 'b: 'a,
       G: Graph+'b,
-      G::Communicator: Clone,
       D: Data+Hash+Eq+Debug+Columnar {
     // build up a subgraph using the concatenated inputs/feedbacks
-    let comm = graph.borrow_mut().communicator().clone();
-    let mut subgraph = (graph.borrow_mut().new_subgraph::<u64>(), comm);
+    let mut graph_borrow = graph.borrow_mut();
 
-    let (sub_egress1, sub_egress2) = {
-        let subgraph_builder = subgraph.builder();//RefCell::new(&mut subgraph);
+    let (subscope, sub_egresses) = {
+        let mut subgraph = (graph_borrow.new_subgraph::<u64>(), graph_borrow.communicator());
 
-        (
-            source1.enter(&subgraph_builder).distinct().leave(graph),
-            source2.enter(&subgraph_builder).leave(graph)
-        )
+        let sub_egresses = {
+            let subgraph_builder = subgraph.builder();//RefCell::new(&mut subgraph);
+
+            (
+                source1.enter(&subgraph_builder).distinct().leave(graph),
+                source2.enter(&subgraph_builder).leave(graph)
+            )
+        };
+
+        (subgraph.0, sub_egresses)
     };
 
-    graph.borrow_mut().add_scope(subgraph.0);
+    graph_borrow.add_scope(subscope);
 
-    return (sub_egress1, sub_egress2);
+    sub_egresses
 }

--- a/src/communication/allocator.rs
+++ b/src/communication/allocator.rs
@@ -14,7 +14,7 @@ use std::default::Default;
 // The Communicator trait presents the interface a worker has to the outside world.
 // The worker can see its index, the total number of peers, and acquire channels to and from the other workers.
 // There is an assumption that each worker performs the same channel allocation logic; things go wrong otherwise.
-pub trait Communicator : 'static {
+pub trait Communicator {
     fn index(&self) -> u64;     // number out of peers
     fn peers(&self) -> u64;     // number of peers
     fn new_channel<T:Send+Columnar+Any>(&mut self) -> (Vec<Box<Pushable<T>>>, Box<Pullable<T>>);
@@ -23,10 +23,10 @@ pub trait Communicator : 'static {
 // TODO : Would be nice if Communicator had associated types for its Pushable and Pullable types,
 // TODO : but they would have to be generic over T, with the current set-up. Might require HKT?
 
-impl<C: Communicator> Communicator for Rc<RefCell<C>> {
-    fn index(&self) -> u64 { self.borrow().index() }
-    fn peers(&self) -> u64 { self.borrow().peers() }
-    fn new_channel<T:Send+Columnar+Any>(&mut self) -> (Vec<Box<Pushable<T>>>, Box<Pullable<T>>) { self.borrow_mut().new_channel() }
+impl<'a, C: Communicator + 'a> Communicator for &'a mut C {
+    fn index(&self) -> u64 { (**self).index() }
+    fn peers(&self) -> u64 { (**self).peers() }
+    fn new_channel<T:Send+Columnar+Any>(&mut self) -> (Vec<Box<Pushable<T>>>, Box<Pullable<T>>) { (**self).new_channel() }
 }
 
 // The simplest communicator remains worker-local and just queues sent messages.

--- a/src/example/graph_builder.rs
+++ b/src/example/graph_builder.rs
@@ -25,7 +25,7 @@ pub trait EnterSubgraphExt<TOuter: Timestamp, TInner: Timestamp, D: Data, C: Com
     fn enter<'a, 'b>(&mut self, subgraph: &'a RefCell<&'b mut (Subgraph<TOuter, TInner>, C)>) -> Stream<'a, 'b, (Subgraph<TOuter, TInner>, C), D>;
 }
 
-impl<'aa, 'bb, GOuter: Graph, TInner: Timestamp, D: Data, C: Communicator + Clone> EnterSubgraphExt<GOuter::Timestamp, TInner, D, C> for Stream<'aa, 'bb, GOuter, D> {
+impl<'aa, 'bb, GOuter: Graph, TInner: Timestamp, D: Data, C: Communicator> EnterSubgraphExt<GOuter::Timestamp, TInner, D, C> for Stream<'aa, 'bb, GOuter, D> {
     fn enter<'a, 'b>(&mut self, subgraph: &'a RefCell<&'b mut (Subgraph<GOuter::Timestamp, TInner>, C)>) -> Stream<'a, 'b, (Subgraph<GOuter::Timestamp, TInner>, C), D> {
 
         let targets = OutputPort::<Product<GOuter::Timestamp, TInner>, D>::new();
@@ -52,7 +52,7 @@ pub trait LeaveSubgraphExt<GOuter: Graph, D: Data> {
     fn leave<'a, 'b>(&mut self, graph: &'a RefCell<&'b mut GOuter>) -> Stream<'a, 'b, GOuter, D>  where 'b: 'a, GOuter: 'b ;
 }
 
-impl<'aa, 'bb, GOuter: Graph, TInner: Timestamp, D: Data> LeaveSubgraphExt<GOuter, D> for Stream<'aa, 'bb, (Subgraph<GOuter::Timestamp, TInner>, GOuter::Communicator), D> {
+impl<'aa, 'bb, 'comm,  GOuter: Graph, TInner: Timestamp, D: Data> LeaveSubgraphExt<GOuter, D> for Stream<'aa, 'bb, (Subgraph<GOuter::Timestamp, TInner>, &'comm mut GOuter::Communicator), D> where GOuter::Communicator: 'comm {
     fn leave<'a, 'b>(&mut self, graph: &'a RefCell<&'b mut GOuter>) -> Stream<'a, 'b, GOuter, D>  where 'b: 'a, GOuter: 'b  {
 
         let index = self.graph.borrow_mut().0.new_output();

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -587,9 +587,9 @@ impl<TOuter: Timestamp, TInner: Timestamp> Subgraph<TOuter, TInner> {
     }
 }
 
-pub fn new_graph<T: Timestamp, C: Communicator>(mut communicator: C) -> (Subgraph<(), T>, Rc<RefCell<C>>) {
+pub fn new_graph<T: Timestamp, C: Communicator>(mut communicator: C) -> (Subgraph<(), T>, C) {
     let progcaster = Progcaster::new(&mut communicator);
-    return (Subgraph::new_from(progcaster), Rc::new(RefCell::new(communicator)));
+    return (Subgraph::new_from(progcaster), communicator);
 }
 
 fn try_to_add_summary<S: PartialOrd+Eq+Copy+Debug>(vector: &mut Vec<(Target, Antichain<S>)>, target: Target, summary: S) -> bool {


### PR DESCRIPTION
With this change, `Communicator`s are no longer wrapped in `Rc` and are no longer cloned. The `FeedbackObserver` needed to be changed to avoid referencing the lifetimes in `Graph`. The borrow fiddling that is now in `_create_subgraph` is a bit unfortunate, but should be factor out-able.