### PR TITLE
Make ActiveStream and SubgraphBuilder take their graphs by value

### DIFF
--- a/src/example_static/builder.rs
+++ b/src/example_static/builder.rs
@@ -6,16 +6,36 @@ use progress::nested::product::Product;
 use progress::nested::scope_wrapper::ScopeWrapper;
 use communication::{Communicator, ThreadCommunicator};
 
-pub trait GraphBuilder {
+pub trait GraphBuilder: Sized {
     type Timestamp : Timestamp;
     type Communicator : Communicator;
 
     fn connect(&mut self, source: Source, target: Target);
     fn add_boxed_scope(&mut self, scope: Box<Scope<Self::Timestamp>>) -> u64;
     fn add_scope<SC: Scope<Self::Timestamp>+'static>(&mut self, scope: SC) -> u64 { self.add_boxed_scope(Box::new(scope)) }
-    fn new_subgraph<'a, T: Timestamp>(&'a mut self) -> SubgraphBuilder<'a, Self, T>;
+    fn new_subscope<T: Timestamp>(&mut self) -> Subgraph<Self::Timestamp, T>;
 
     fn communicator(&mut self) -> &mut Self::Communicator;
+
+    fn new_subgraph<'a, T: Timestamp>(&'a mut self) -> SubgraphBuilder<'a, Self, T> {
+        let subscope = self.new_subscope();
+        SubgraphBuilder {
+            subgraph: subscope,
+            parent: self
+        }
+    }
+}
+
+impl<'a, G: GraphBuilder+'a> GraphBuilder for &'a mut G {
+    type Timestamp = G::Timestamp;
+    type Communicator = G::Communicator;
+
+    fn connect(&mut self, source: Source, target: Target) { (**self).connect(source, target) }
+    fn add_boxed_scope(&mut self, scope: Box<Scope<Self::Timestamp>>) -> u64 { (**self).add_boxed_scope(scope) }
+    fn add_scope<SC: Scope<Self::Timestamp>+'static>(&mut self, scope: SC) -> u64 { self.add_boxed_scope(Box::new(scope)) }
+    fn new_subscope<T: Timestamp>(&mut self) -> Subgraph<Self::Timestamp, T> { (**self).new_subscope() }
+
+    fn communicator(&mut self) -> &mut Self::Communicator { (**self).communicator() }
 }
 
 pub struct GraphRoot<C: Communicator> {
@@ -51,11 +71,9 @@ impl<C: Communicator> GraphBuilder for GraphRoot<C> {
             0
         }
     }
-    fn new_subgraph<'a, T: Timestamp>(&'a mut self) -> SubgraphBuilder<'a, Self, T>  {
-        SubgraphBuilder {
-            subgraph: Subgraph::<(), T>::new_from(&mut self.communicator, 0),
-            parent:   self,
-        }
+
+    fn new_subscope<T: Timestamp>(&mut self) -> Subgraph<(), T>  {
+        Subgraph::<(), T>::new_from(&mut self.communicator, 0)
     }
 
     fn communicator(&mut self) -> &mut C { &mut self.communicator }
@@ -89,11 +107,8 @@ impl<'a, G: GraphBuilder+'a, T: Timestamp> GraphBuilder for SubgraphBuilder<'a, 
         index
     }
 
-    fn new_subgraph<'b, T2: Timestamp>(&'b mut self) -> SubgraphBuilder<'b, Self, T2> {
-        SubgraphBuilder {
-            subgraph: Subgraph::new_from(self.parent.communicator(), self.subgraph.children() as u64),
-            parent:   self,
-        }
+    fn new_subscope<T2: Timestamp>(&mut self) -> Subgraph<Product<G::Timestamp, T>, T2> {
+        Subgraph::new_from(self.parent.communicator(), self.subgraph.children() as u64)
     }
 
     fn communicator(&mut self) -> &mut G::Communicator { self.parent.communicator() }

--- a/src/example_static/concat.rs
+++ b/src/example_static/concat.rs
@@ -28,11 +28,11 @@ use example_static::builder::*;
 // }
 
 pub trait ConcatVecExt<G: GraphBuilder, D: Data> {
-    fn concatenate<'a>(&'a mut self, Vec<Stream<G::Timestamp, D>>) -> ActiveStream<'a, G, D>;
+    fn concatenate<'a>(&'a mut self, Vec<Stream<G::Timestamp, D>>) -> ActiveStream<&'a mut G, D>;
 }
 
 impl<G: GraphBuilder, D: Data> ConcatVecExt<G, D> for G {
-    fn concatenate<'a>(&'a mut self, sources: Vec<Stream<G::Timestamp, D>>) -> ActiveStream<'a, G, D> {
+    fn concatenate<'a>(&'a mut self, sources: Vec<Stream<G::Timestamp, D>>) -> ActiveStream<&'a mut G, D> {
 
         if sources.len() == 0 { panic!("must pass at least one stream to concat"); }
 

--- a/src/example_static/distinct.rs
+++ b/src/example_static/distinct.rs
@@ -15,8 +15,8 @@ use columnar::Columnar;
 
 pub trait DistinctExtensionTrait { fn distinct(self) -> Self; }
 
-impl<'a, G: GraphBuilder+'a, D: Data+Hash+Eq+Columnar> DistinctExtensionTrait for ActiveStream<'a, G, D> {
-    fn distinct(self) -> ActiveStream<'a, G, D> {
+impl<G: GraphBuilder, D: Data+Hash+Eq+Columnar> DistinctExtensionTrait for ActiveStream<G, D> {
+    fn distinct(self) -> ActiveStream<G, D> {
         let mut elements: HashMap<_, HashSet<_, DefaultState<SipHasher>>> = HashMap::new();
         self.unary(Exchange::new(|x| hash::<_,SipHasher>(&x)), format!("Distinct"), move |handle| {
             // read input data into sets, request notifications

--- a/src/example_static/enterleave.rs
+++ b/src/example_static/enterleave.rs
@@ -14,15 +14,15 @@ use communication::channels::{Data, OutputPort, ObserverHelper};
 use example_static::builder::{GraphBuilder, SubgraphBuilder};
 use example_static::stream::*;
 
-pub trait EnterSubgraphExt<'outer, G: GraphBuilder+'outer, T: Timestamp, D: Data> {
-    fn enter<'inner>(&'inner mut self, &Stream<G::Timestamp, D>) ->
-        ActiveStream<&'inner mut SubgraphBuilder<'outer, G, T>, D> where 'outer: 'inner;
+pub trait EnterSubgraphExt<G: GraphBuilder, T: Timestamp, D: Data> {
+    fn enter<'a>(&'a mut self, &Stream<G::Timestamp, D>) ->
+        ActiveStream<&'a mut SubgraphBuilder<G, T>, D>;
 }
 
-impl<'outer, T: Timestamp, G: GraphBuilder+'outer, D: Data>
-EnterSubgraphExt<'outer, G, T, D> for SubgraphBuilder<'outer, G, T> {
-    fn enter<'inner>(&'inner mut self, stream: &Stream<G::Timestamp, D>) ->
-        ActiveStream<&'inner mut SubgraphBuilder<'outer, G, T>, D> where 'outer: 'inner {
+impl<T: Timestamp, G: GraphBuilder, D: Data>
+EnterSubgraphExt<G, T, D> for SubgraphBuilder<G, T> {
+    fn enter<'a>(&'a mut self, stream: &Stream<G::Timestamp, D>) ->
+        ActiveStream<&'a mut SubgraphBuilder<G, T>, D> {
 
         let targets = OutputPort::<Product<G::Timestamp, T>, D>::new();
         let produced = Rc::new(RefCell::new(CountMap::new()));
@@ -38,12 +38,12 @@ EnterSubgraphExt<'outer, G, T, D> for SubgraphBuilder<'outer, G, T> {
     }
 }
 
-pub trait LeaveSubgraphExt<'outer, G: GraphBuilder+'outer, D: Data> {
+pub trait LeaveSubgraphExt<G: GraphBuilder, D: Data> {
     fn leave(&mut self) -> Stream<G::Timestamp, D>;
 }
 
-impl<'inner, 'outer: 'inner, G: GraphBuilder+'outer, D: Data, TInner: Timestamp> LeaveSubgraphExt<'outer, G, D>
-for ActiveStream<&'inner mut SubgraphBuilder<'outer, G, TInner>, D> where G::Communicator: 'inner {
+impl<'a, G: GraphBuilder+'a, D: Data, TInner: Timestamp> LeaveSubgraphExt<G, D>
+for ActiveStream<&'a mut SubgraphBuilder<G, TInner>, D> where G::Communicator: 'a {
     fn leave(&mut self) -> Stream<G::Timestamp, D> {
 
         let output_index = self.builder.subgraph.new_output();

--- a/src/example_static/enterleave.rs
+++ b/src/example_static/enterleave.rs
@@ -16,13 +16,13 @@ use example_static::stream::*;
 
 pub trait EnterSubgraphExt<'outer, G: GraphBuilder+'outer, T: Timestamp, D: Data> {
     fn enter<'inner>(&'inner mut self, &Stream<G::Timestamp, D>) ->
-        ActiveStream<'inner, SubgraphBuilder<'outer, G, T>, D> where 'outer: 'inner;
+        ActiveStream<&'inner mut SubgraphBuilder<'outer, G, T>, D> where 'outer: 'inner;
 }
 
 impl<'outer, T: Timestamp, G: GraphBuilder+'outer, D: Data>
 EnterSubgraphExt<'outer, G, T, D> for SubgraphBuilder<'outer, G, T> {
     fn enter<'inner>(&'inner mut self, stream: &Stream<G::Timestamp, D>) ->
-        ActiveStream<'inner, SubgraphBuilder<'outer, G, T>, D> where 'outer: 'inner {
+        ActiveStream<&'inner mut SubgraphBuilder<'outer, G, T>, D> where 'outer: 'inner {
 
         let targets = OutputPort::<Product<G::Timestamp, T>, D>::new();
         let produced = Rc::new(RefCell::new(CountMap::new()));
@@ -43,7 +43,7 @@ pub trait LeaveSubgraphExt<'outer, G: GraphBuilder+'outer, D: Data> {
 }
 
 impl<'inner, 'outer: 'inner, G: GraphBuilder+'outer, D: Data, TInner: Timestamp> LeaveSubgraphExt<'outer, G, D>
-for ActiveStream<'inner, SubgraphBuilder<'outer, G, TInner>, D> {
+for ActiveStream<&'inner mut SubgraphBuilder<'outer, G, TInner>, D> where G::Communicator: 'inner {
     fn leave(&mut self) -> Stream<G::Timestamp, D> {
 
         let output_index = self.builder.subgraph.new_output();

--- a/src/example_static/flat_map.rs
+++ b/src/example_static/flat_map.rs
@@ -5,12 +5,12 @@ use example_static::builder::GraphBuilder;
 use example_static::stream::ActiveStream;
 use example_static::unary::UnaryExt;
 
-pub trait FlatMapExt<'a, G: GraphBuilder+'a, D1: Data> {
-    fn flat_map<D2: Data, I: Iterator<Item=D2>, L: Fn(D1)->I+'static>(self, logic: L) -> ActiveStream<'a, G, D2>;
+pub trait FlatMapExt<G: GraphBuilder, D1: Data> {
+    fn flat_map<D2: Data, I: Iterator<Item=D2>, L: Fn(D1)->I+'static>(self, logic: L) -> ActiveStream<G, D2>;
 }
 
-impl<'a, G: GraphBuilder+'a, D1: Data> FlatMapExt<'a, G, D1> for ActiveStream<'a, G, D1> {
-    fn flat_map<D2: Data, I: Iterator<Item=D2>, L: Fn(D1)->I+'static>(self, logic: L) -> ActiveStream<'a, G, D2> {
+impl<G: GraphBuilder, D1: Data> FlatMapExt<G, D1> for ActiveStream<G, D1> {
+    fn flat_map<D2: Data, I: Iterator<Item=D2>, L: Fn(D1)->I+'static>(self, logic: L) -> ActiveStream<G, D2> {
         self.unary(Pipeline, format!("Select"), move |handle| {
             while let Some((time, data)) = handle.input.pull() {
                 handle.output.give_at(&time, data.into_iter().flat_map(|x| logic(x)));

--- a/src/example_static/inspect.rs
+++ b/src/example_static/inspect.rs
@@ -9,8 +9,8 @@ pub trait InspectExt<D: Data> {
     fn inspect<F: FnMut(&D)+'static>(self, func: F) -> Self;
 }
 
-impl<'a, G: GraphBuilder+'a, D: Data> InspectExt<D> for ActiveStream<'a, G, D> {
-    fn inspect<F: FnMut(&D)+'static>(self, mut func: F) -> ActiveStream<'a, G, D> {
+impl<G: GraphBuilder, D: Data> InspectExt<D> for ActiveStream<G, D> {
+    fn inspect<F: FnMut(&D)+'static>(self, mut func: F) -> ActiveStream<G, D> {
         self.unary(Pipeline, format!("Inspect"), move |handle| {
             while let Some((time, data)) = handle.input.pull() {
                 let mut session = handle.output.session(&time);
@@ -28,8 +28,8 @@ pub trait InspectBatchExt<G: GraphBuilder, D: Data> {
     fn inspect_batch<F: FnMut(&G::Timestamp, &Vec<D>)+'static>(self, mut func: F) -> Self;
 }
 
-impl<'a, G: GraphBuilder+'a, D: Data> InspectBatchExt<G, D> for ActiveStream<'a, G, D> {
-    fn inspect_batch<F: FnMut(&G::Timestamp, &Vec<D>)+'static>(self, mut func: F) -> ActiveStream<'a, G, D> {
+impl<G: GraphBuilder, D: Data> InspectBatchExt<G, D> for ActiveStream<G, D> {
+    fn inspect_batch<F: FnMut(&G::Timestamp, &Vec<D>)+'static>(self, mut func: F) -> ActiveStream<G, D> {
         self.unary(Pipeline, format!("Inspect"), move |handle| {
             while let Some((time, data)) = handle.input.pull() {
                 func(&time, &data);

--- a/src/example_static/map.rs
+++ b/src/example_static/map.rs
@@ -6,12 +6,12 @@ use example_static::builder::*;
 use example_static::stream::ActiveStream;
 use example_static::unary::UnaryExt;
 
-pub trait MapExt<'a, G: GraphBuilder+'a, D1: Data> {
-    fn map<D2: Data, L: Fn(D1)->D2+'static>(self, logic: L) -> ActiveStream<'a, G, D2>;
+pub trait MapExt<G: GraphBuilder, D1: Data> {
+    fn map<D2: Data, L: Fn(D1)->D2+'static>(self, logic: L) -> ActiveStream<G, D2>;
 }
 
-impl<'a, G: GraphBuilder+'a, D1: Data> MapExt<'a, G, D1> for ActiveStream<'a, G, D1> {
-    fn map<D2: Data, L: Fn(D1)->D2+'static>(self, logic: L) -> ActiveStream<'a, G, D2> {
+impl<G: GraphBuilder, D1: Data> MapExt<G, D1> for ActiveStream<G, D1> {
+    fn map<D2: Data, L: Fn(D1)->D2+'static>(self, logic: L) -> ActiveStream<G, D2> {
         self.unary(Pipeline, format!("Select"), move |handle| {
             while let Some((time, data)) = handle.input.pull() {
                 handle.output.give_at(&time, data.into_iter().map(|x| logic(x)));

--- a/src/example_static/partition.rs
+++ b/src/example_static/partition.rs
@@ -15,12 +15,12 @@ use example_static::stream::{Stream, ActiveStream};
 use example_static::unary::PullableHelper;
 
 
-pub trait PartitionExt<'a, G: GraphBuilder+'a, D: Data, F: Fn(&D)->u64> {
-    fn partition(self, parts: u64, func: F) -> (Vec<Stream<G::Timestamp, D>>, &'a mut G);
+pub trait PartitionExt<G: GraphBuilder, D: Data, F: Fn(&D)->u64> {
+    fn partition(self, parts: u64, func: F) -> (Vec<Stream<G::Timestamp, D>>, G);
 }
 
-impl<'a, G: GraphBuilder+'a, D: Data, F: Fn(&D)->u64+'static> PartitionExt<'a, G, D, F> for ActiveStream<'a, G, D> {
-    fn partition(mut self, parts: u64, func: F) -> (Vec<Stream<G::Timestamp, D>>, &'a mut G) {
+impl<G: GraphBuilder, D: Data, F: Fn(&D)->u64+'static> PartitionExt<G, D, F> for ActiveStream<G, D> {
+    fn partition(mut self, parts: u64, func: F) -> (Vec<Stream<G::Timestamp, D>>, G) {
 
         let (sender, receiver) = Pipeline.connect(self.builder.communicator());
         let mut targets = Vec::new();

--- a/src/example_static/stream.rs
+++ b/src/example_static/stream.rs
@@ -24,21 +24,21 @@ impl<T: Timestamp, D:Data> Stream<T, D> {
 }
 
 pub trait EnableExt<'a, G: GraphBuilder+'a> {
-    fn enable<D: Data>(&'a mut self, stream: &Stream<G::Timestamp, D>) -> ActiveStream<'a, G, D>;
+    fn enable<D: Data>(&'a mut self, stream: &Stream<G::Timestamp, D>) -> ActiveStream<&'a mut G, D>;
 }
 
 impl<'a, G: GraphBuilder+'a> EnableExt<'a, G> for G {
-    fn enable<D: Data>(&'a mut self, stream: &Stream<G::Timestamp, D>) -> ActiveStream<'a, G, D> {
+    fn enable<D: Data>(&'a mut self, stream: &Stream<G::Timestamp, D>) -> ActiveStream<&'a mut G, D> {
         ActiveStream { stream: stream.clone(), builder: self }
     }
 }
 
-pub struct ActiveStream<'a, G: GraphBuilder+'a, D: Data> {
+pub struct ActiveStream<G: GraphBuilder, D: Data> {
     pub stream:  Stream<G::Timestamp, D>,
-    pub builder: &'a mut G,
+    pub builder: G,
 }
 
-impl<'a, G: GraphBuilder+'a, D: Data> ActiveStream<'a, G, D> {
+impl<G: GraphBuilder, D: Data> ActiveStream<G, D> {
     pub fn disable(self) -> Stream<G::Timestamp, D> {
         self.stream
     }
@@ -48,7 +48,8 @@ impl<'a, G: GraphBuilder+'a, D: Data> ActiveStream<'a, G, D> {
         self.builder.connect(self.stream.name, target);
         self.stream.ports.add_observer(observer);
     }
-    pub fn transfer_borrow_to<D2: Data>(self, source: Source, ports: OutputPort<G::Timestamp, D2>) -> ActiveStream<'a, G, D2> {
+
+    pub fn transfer_borrow_to<D2: Data>(self, source: Source, ports: OutputPort<G::Timestamp, D2>) -> ActiveStream<G, D2> {
         ActiveStream {
             stream: Stream {
                 name: source,

--- a/src/example_static/unary.rs
+++ b/src/example_static/unary.rs
@@ -56,18 +56,18 @@ impl<T:Timestamp, D:Data, P: Pullable<(T, Vec<D>)>> PullableHelper<T, D, P> {
 }
 
 
-pub trait UnaryExt<'a, G: GraphBuilder, D1: Data> {
+pub trait UnaryExt<G: GraphBuilder, D1: Data> {
     fn unary<D2: Data,
              L: FnMut(&mut UnaryScopeHandle<G::Timestamp, D1, D2, P::Pullable>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
-            (self, pact: P, name: String, logic: L) -> ActiveStream<'a, G, D2>;
+            (self, pact: P, name: String, logic: L) -> ActiveStream<G, D2>;
 }
 
-impl<'a, G: GraphBuilder+'a, D1: Data> UnaryExt<'a, G, D1> for ActiveStream<'a, G, D1> {
+impl<G: GraphBuilder, D1: Data> UnaryExt<G, D1> for ActiveStream<G, D1> {
     fn unary<D2: Data,
              L: FnMut(&mut UnaryScopeHandle<G::Timestamp, D1, D2, P::Pullable>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
-             (mut self, pact: P, name: String, logic: L) -> ActiveStream<'a, G, D2> {
+             (mut self, pact: P, name: String, logic: L) -> ActiveStream<G, D2> {
         let (sender, receiver) = pact.connect(self.builder.communicator());
         let targets = OutputPort::<G::Timestamp,D2>::new();
         let scope = UnaryScope::new(receiver, targets.clone(), name, logic);


### PR DESCRIPTION
I held back on the `impl GraphBuilder for &RefCell<GraphBuilder>`, but it should be possible (with a switch back to `with_comminicator`).