### PR TITLE
Make CountMap more opaque

### DIFF
--- a/src/dataflow/operators/capture.rs
+++ b/src/dataflow/operators/capture.rs
@@ -287,14 +287,14 @@ impl<T:Timestamp, D: Data, P: EventPusher<T, D>> Operate<T> for CaptureOperator<
 
     // we need to set the initial value of the frontier
     fn set_external_summary(&mut self, _: Vec<Vec<Antichain<T::Summary>>>, counts: &mut [CountMap<T>]) {
-        self.events.push(Event::Progress(counts[0].updates.clone()));
-        counts[0].updates.clear();
+        self.events.push(Event::Progress(counts[0].clone().into_inner()));
+        counts[0].clear();
     }
 
     // each change to the frontier should be shared
     fn push_external_progress(&mut self, counts: &mut [CountMap<T>]) {
-        self.events.push(Event::Progress(counts[0].updates.clone()));
-        counts[0].updates.clear();
+        self.events.push(Event::Progress(counts[0].clone().into_inner()));
+        counts[0].clear();
     }
 
     fn pull_internal_progress(&mut self, consumed: &mut [CountMap<T>],  _: &mut [CountMap<T>], _: &mut [CountMap<T>]) -> bool {

--- a/src/progress/broadcast.rs
+++ b/src/progress/broadcast.rs
@@ -35,14 +35,14 @@ impl<T:Timestamp+Send> Progcaster<T> {
     {
 
         // // we should not be sending zero deltas.
-        // assert!(messages.elements().iter().all(|x| x.1 != 0));
-        // assert!(internal.elements().iter().all(|x| x.1 != 0));
+        // assert!(messages.iter().all(|x| x.1 != 0));
+        // assert!(internal.iter().all(|x| x.1 != 0));
         if self.pushers.len() > 1 {  // if the length is one, just return the updates...
             if messages.len() > 0 || internal.len() > 0 {
                 for pusher in self.pushers.iter_mut() {
                     // TODO : Feels like an Arc might be not horrible here... less allocation,
                     // TODO : at least, but more "contention" in the deallocation.
-                    pusher.push(&mut Some((messages.elements().clone(), internal.elements().clone())));
+                    pusher.push(&mut Some((messages.clone().into_inner(), internal.clone().into_inner())));
                 }
 
                 messages.clear();

--- a/src/progress/count_map.rs
+++ b/src/progress/count_map.rs
@@ -1,6 +1,7 @@
 //! A mapping from general types `T` to `i64`, with zero values absent.
 
 use std::default::Default;
+use std::slice::Iter;
 
 // could be updated to be an Enum { Vec<(T, i64)>, HashMap<T, i64> } in the fullness of time
 #[derive(Clone, Debug)]
@@ -35,7 +36,7 @@ impl<T:Eq+Clone> CountMap<T> {
     }
 
     pub fn into_inner(self) -> Vec<(T, i64)> { self.updates }
-    pub fn elements<'a>(&'a self) -> &'a Vec<(T, i64)> { &self.updates }
+    pub fn iter<'a>(&'a self) -> Iter<'a, (T, i64)> { self.updates.iter() }
     pub fn clear(&mut self) { self.updates.clear(); }
     pub fn len(&self) -> usize { self.updates.len() }
     pub fn pop(&mut self) -> Option<(T, i64)> { self.updates.pop() }

--- a/src/progress/count_map.rs
+++ b/src/progress/count_map.rs
@@ -5,7 +5,7 @@ use std::default::Default;
 // could be updated to be an Enum { Vec<(T, i64)>, HashMap<T, i64> } in the fullness of time
 #[derive(Clone, Debug)]
 pub struct CountMap<T> {
-    pub updates: Vec<(T, i64)>
+    updates: Vec<(T, i64)>
 }
 
 impl<T> Default for CountMap<T> {
@@ -34,6 +34,7 @@ impl<T:Eq+Clone> CountMap<T> {
         else { 0 }
     }
 
+    pub fn into_inner(self) -> Vec<(T, i64)> { self.updates }
     pub fn elements<'a>(&'a self) -> &'a Vec<(T, i64)> { &self.updates }
     pub fn clear(&mut self) { self.updates.clear(); }
     pub fn len(&self) -> usize { self.updates.len() }

--- a/src/progress/frontier.rs
+++ b/src/progress/frontier.rs
@@ -103,13 +103,13 @@ impl<T: PartialOrd+Eq+Clone+Debug+'static> MutableAntichain<T> {
     /// Returns the number of times an element exists in the set.
     #[inline]
     pub fn count(&self, time: &T) -> Option<i64> {
-        self.occurrences.elements().iter().filter(|x| time.eq(&x.0)).next().map(|i| i.1)
+        self.occurrences.iter().filter(|x| time.eq(&x.0)).next().map(|i| i.1)
     }
 
     // TODO : Four different versions of basically the same code. Fix that!
     // TODO : Should this drain updates through to the CM? Check out uses!
     pub fn update_into_cm(&mut self, updates: &CountMap<T>, results: &mut CountMap<T>) -> () {
-        self.update_iter_and(updates.elements().iter().map(|x| x.clone()), |time, val| { results.update(time, val); });
+        self.update_iter_and(updates.iter().cloned(), |time, val| { results.update(time, val); });
     }
 
     pub fn update_weight(&mut self, elem: &T, delta: i64, results: &mut CountMap<T>) -> () {

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -115,7 +115,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         // that they are `Product<TOuter, TInner>`, and we just want `TOuter`.
         let mut initial_capabilities = vec![CountMap::new(); self.outputs()];
         for (o_port, capabilities) in self.pointstamps.pushed[0].iter().enumerate() {
-            for &(time, val) in capabilities.elements() {
+            for &(time, val) in capabilities.iter() {
                 // make a note to self and inform scope of our capability.
                 self.output_capabilities[o_port].update(&time.outer, val);
                 initial_capabilities[o_port].update(&time.outer, val);
@@ -778,7 +778,7 @@ impl<T: Timestamp> PerOperatorState<T> {
 
         // TODO : Gross. Fix.
         for (index, capability) in result.internal.iter_mut().enumerate() {
-            capability.update_iter_and(work[index].elements().iter().map(|x|x.clone()), |_, _| {});
+            capability.update_iter_and(work[index].iter().cloned(), |_, _| {});
         }
 
         return result;


### PR DESCRIPTION
This is a breaking change, but it leaves more freedom to change the representation of `CountMap` later.