### PR TITLE
Opening a Session borrows the capability for as long as the session is open

### DIFF
--- a/src/dataflow/operators/handles.rs
+++ b/src/dataflow/operators/handles.rs
@@ -94,7 +94,7 @@ impl<'a, T: Timestamp, D, P: Push<(T, Content<D>)>> OutputHandle<'a, T, D, P> {
     ///            });
     /// });
     /// ```
-    pub fn session<'b>(&'b mut self, cap: &Capability<T>) -> Session<'b, T, D, PushCounter<T, D, P>> where 'a: 'b {
+    pub fn session<'b>(&'b mut self, cap: &'b Capability<T>) -> Session<'b, T, D, PushCounter<T, D, P>> where 'a: 'b {
         self.push_buffer.session(cap)
     }
 }


### PR DESCRIPTION

This prevents dropping the capability while it's still "in use", i.e.
data is being sent at the associated timestamp