### PR TITLE
Statically enforce that references to child scopes don't escape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/frankmcsherry/timely-dataflow.git"
 keywords = ["timely", "dataflow"]
 license = "MIT"
 
-#[dependencies.timely_communication]
-#path="./communication"
+[dependencies.timely_communication]
+path="./communication"
 
 [features]
 default=[]
@@ -23,7 +23,7 @@ logging=[]
 [dependencies]
 abomonation="^0.4.2"
 timely_sort="0.1.3"
-timely_communication="^0.1.4"
+#timely_communication="^0.1.4"
 byteorder="0.4.2"
 time="0.1.34"
 

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -15,7 +15,7 @@ use {Data, Push, Pull};
 // The Communicator trait presents the interface a worker has to the outside world.
 // The worker can see its index, the total number of peers, and acquire channels to and from the other workers.
 // There is an assumption that each worker performs the same channel allocation logic; things go wrong otherwise.
-pub trait Allocate: 'static {
+pub trait Allocate {
     /// The index of the worker out of `(0..self.peers())`.
     fn index(&self) -> usize;
     /// The number of workers.

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -27,7 +27,7 @@ use dataflow::scopes::{Child, Root};
 // NOTE : Might be able to fix with another lifetime parameter, say 'c: 'a.
 
 /// Create a new `Stream` and `Handle` through which to supply input.
-pub trait Input<A: Allocate, T: Timestamp+Ord> {
+pub trait Input<'a, A: Allocate, T: Timestamp+Ord> {
     /// Create a new `Stream` and `Handle` through which to supply input.
     ///
     /// The `new_input` method returns a pair `(Handle, Stream)` where the `Stream` can be used
@@ -62,11 +62,11 @@ pub trait Input<A: Allocate, T: Timestamp+Ord> {
     ///     }
     /// });
     /// ```
-    fn new_input<D:Data>(&mut self) -> (Handle<T, D>, Stream<Child<Root<A>, T>, D>);
+    fn new_input<D:Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>);
 }
 
-impl<A: Allocate, T: Timestamp+Ord> Input<A, T> for Child<Root<A>, T> {
-    fn new_input<D:Data>(&mut self) -> (Handle<T, D>, Stream<Child<Root<A>, T>, D>) {
+impl<'a, A: Allocate, T: Timestamp+Ord> Input<'a, A, T> for Child<'a, Root<A>, T> {
+    fn new_input<D:Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>) {
 
         let (output, registrar) = Tee::<Product<RootTimestamp, T>, D>::new();
         let produced = Rc::new(RefCell::new(CountMap::new()));

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -12,17 +12,17 @@ use super::Scope;
 
 /// A `Child` wraps a `Subgraph` and a parent `G: Scope`. It manages the addition
 /// of `Operate`s to a subgraph, and the connection of edges between them.
-pub struct Child<G: Scope, T: Timestamp> {
-    pub subgraph: Rc<RefCell<Subgraph<G::Timestamp, T>>>,
+pub struct Child<'a, G: Scope, T: Timestamp> {
+    pub subgraph: &'a RefCell<Subgraph<G::Timestamp, T>>,
     pub parent:   G,
 }
 
-impl<G: Scope, T: Timestamp> Child<G, T> {
+impl<'a, G: Scope, T: Timestamp> Child<'a, G, T> {
     pub fn index(&self) -> usize { self.parent.index() }
     pub fn peers(&self) -> usize { self.parent.peers() }
 }
 
-impl<G: Scope, T: Timestamp> Scope for Child<G, T> {
+impl<'a, G: Scope, T: Timestamp> Scope for Child<'a, G, T> {
     type Timestamp = Product<G::Timestamp, T>;
 
     fn name(&self) -> String { self.subgraph.borrow().name().to_owned() }
@@ -53,7 +53,7 @@ impl<G: Scope, T: Timestamp> Scope for Child<G, T> {
     }
 }
 
-impl<G: Scope, T: Timestamp> Allocate for Child<G, T> {
+impl<'a, G: Scope, T: Timestamp> Allocate for Child<'a, G, T> {
     fn index(&self) -> usize { self.parent.index() }
     fn peers(&self) -> usize { self.parent.peers() }
     fn allocate<D: Data>(&mut self) -> (Vec<Box<Push<D>>>, Box<Pull<D>>) {
@@ -61,6 +61,6 @@ impl<G: Scope, T: Timestamp> Allocate for Child<G, T> {
     }
 }
 
-impl<G: Scope, T: Timestamp> Clone for Child<G, T> {
-    fn clone(&self) -> Self { Child { subgraph: self.subgraph.clone(), parent: self.parent.clone() }}
+impl<'a, G: Scope, T: Timestamp> Clone for Child<'a, G, T> {
+    fn clone(&self) -> Self { Child { subgraph: self.subgraph, parent: self.parent.clone() }}
 }

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -70,19 +70,19 @@ pub trait Scope : Allocate+Clone {
     /// ```
     #[inline]
     fn scoped<T: Timestamp, R, F:FnOnce(&mut Child<Self, T>)->R>(&mut self, func: F) -> R {
-        let subscope = Rc::new(RefCell::new(self.new_subscope()));
-        let mut builder = Child {
-            subgraph: subscope,
-            parent: self.clone(),
+        let subscope = RefCell::new(self.new_subscope());
+
+        let result = {
+            let mut builder = Child {
+                subgraph: &subscope,
+                parent: self.clone(),
+            };
+            func(&mut builder)
         };
 
-        let result = func(&mut builder);
-        let index = builder.subgraph.borrow().index;
-        if let Ok(subgraph) = ::std::rc::Rc::try_unwrap(builder.subgraph) {
-            self.add_operator_with_index(subgraph.into_inner(), index);
-            result
-        }
-        else {
-            panic!("scoped: Rc<Subgraph> not fully released");
-        }    }
+        let index = subscope.borrow().index;
+        self.add_operator_with_index(subscope.into_inner(), index);
+
+        result
+    }
 }


### PR DESCRIPTION
cc #36