### PR TITLE
removed time crate; converted times to Instant, Duration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,15 @@ abomonation="^0.4.2"
 timely_sort="0.1.3"
 #timely_communication="^0.1.4"
 byteorder="0.4.2"
-time="0.1.34"
+#time="0.1.34"
 
 [dev-dependencies]
 getopts="0.2.14"
 rand="0.3.13"
+
+[profile.release]
+opt-level = 3
+debug = true
+rpath = false
+lto = false
+debug-assertions = false

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -1,4 +1,3 @@
-extern crate time;
 extern crate rand;
 extern crate timely;
 extern crate timely_sort;
@@ -11,6 +10,7 @@ use timely_sort::LSBRadixSorter as RadixSorter;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 use timely::dataflow::channels::pact::Exchange;
+
 fn main() {
 
     // command-line args: numbers of nodes and edges in the random graph.
@@ -37,7 +37,7 @@ fn main() {
         // holds the bfs parent of each node, or u32::max_value() if unset.
         let mut done = vec![u32::max_value(); 1 + (nodes / peers)];
 
-        let start = time::precise_time_s();
+        let start = ::std::time::Instant::now();
 
         root.scoped(move |scope| {
 
@@ -80,7 +80,7 @@ fn main() {
                         if time.inner == 0 {
 
                             // print some diagnostic timing information
-                            if index == 0 { println!("{}:\tsorting", time::precise_time_s() - start); }
+                            if index == 0 { println!("{:?}:\tsorting", start.elapsed()); }
 
                             // sort the edges
                             sorter.sort(&mut edge_list, &|x| x.0);
@@ -109,7 +109,7 @@ fn main() {
                         }
 
                         // print some diagnostic timing information
-                        if index == 0 { println!("{}:\ttime: {:?}", time::precise_time_s() - start, time.time()); }
+                        if index == 0 { println!("{:?}:\ttime: {:?}", start.elapsed(), time.time()); }
 
                         if let Some(mut todo) = node_lists.remove(&time) {
                             let mut session = output.session(&time);

--- a/examples/unionfind.rs
+++ b/examples/unionfind.rs
@@ -1,4 +1,3 @@
-extern crate time;
 extern crate rand;
 extern crate timely;
 extern crate timely_sort;
@@ -18,6 +17,8 @@ fn main() {
     let edges: usize = std::env::args().nth(2).unwrap().parse().unwrap();
     let batch: usize = std::env::args().nth(3).unwrap().parse().unwrap();
 
+    let start = ::std::time::Instant::now();
+
     timely::execute_from_args(std::env::args().skip(4), move |root| {
 
         let index = root.index();
@@ -27,6 +28,7 @@ fn main() {
 
             let (handle, stream) = scope.new_input();
 
+            // optionally, de-load worker zero who will have enough to do when `peers` is large.
             let probe = stream//.exchange(move |x: &(usize, usize)| (x.0 % (peers - 1)) as u64 + 1)
                               .union_find()
                               .exchange(|_| 0)
@@ -39,18 +41,24 @@ fn main() {
         let seed: &[_] = &[1, 2, 3, index];
         let mut rng: StdRng = SeedableRng::from_seed(seed);
 
-        for edge in 0..(edges / peers) {
-            input.send((rng.gen_range(0, nodes), rng.gen_range(0, nodes)));
+        for edge in 0 .. edges {
+            if edge % peers == index { 
+                input.send((rng.gen_range(0, nodes), rng.gen_range(0, nodes)));
+            }
+
+            // at batch boundaries, advance epoch and sync.
             if edge % batch == (batch - 1) {
                 let next = input.epoch() + 1;
                 input.advance_to(next);
-                while probe.lt(input.time()) {
-                    root.step();
-                }
+                root.step_while(|| probe.lt(input.time()));
             }
         }
 
     }).unwrap(); // asserts error-free execution;
+
+    let elapsed = start.elapsed();
+
+    println!("elapsed: {:?}; avg latency: {:?}", elapsed, elapsed / ((edges / batch) as u32));
 }
 
 trait UnionFind {
@@ -60,14 +68,16 @@ trait UnionFind {
 impl<G: Scope> UnionFind for Stream<G, (usize, usize)> {
     fn union_find(&self) -> Stream<G, (usize, usize)> {
 
-        let mut roots = vec![];  // u32 works, and is smaller than uint/u64
+        let mut roots = vec![];  // u32 can work and is smaller than usize
         let mut ranks = vec![];  // u8 should be large enough (n < 2^256)
 
         self.unary_stream(Pipeline, "UnionFind", move |input, output| {
 
-            while let Some((time, data)) = input.next() {
+            // extract timestamped edges from our input.
+            input.for_each(|time, data| {
 
                 let mut session = output.session(&time);
+
                 for &(mut x, mut y) in data.iter() {
 
                     // grow arrays if required.
@@ -81,6 +91,7 @@ impl<G: Scope> UnionFind for Stream<G, (usize, usize)> {
                     while x != roots[x] { x = roots[x]; }
                     while y != roots[y] { y = roots[y]; }
 
+                    // if not the same, send edge and merge.
                     if x != y {
                         session.give((x, y));
                         match ranks[x].cmp(&ranks[y]) {
@@ -90,7 +101,7 @@ impl<G: Scope> UnionFind for Stream<G, (usize, usize)> {
                         }
                     }
                 }
-            }
+            });
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@
 extern crate abomonation;
 extern crate byteorder;
 extern crate timely_communication;
-extern crate time;
 
 pub use execute::{execute, execute_from_args, example};
 pub use timely_communication::{Push, Pull, Configuration};


### PR DESCRIPTION
Edits to remove the `time` crate as a dependence, and consequently several of its dependencies. Impact seems limited only to the logging subsystem and the attractive output of two of the examples.

In addition to swapping in `std::time::Instant`, initialization creates one `Instant` and supplies it to all the loggers, who use it to generate timestamps rather than the shared static. This has the potential to reveal worker start-up skew in the reported times, which we could fix if we want by augmenting `Root::new()` with an `Instant` parameter for the logging, and which would be minted by `timely::execute()`.

Other folks are using the logging infrastructure, so I want to give them (and anyone, really) a chance to try out and speak up if this subtly breaks their work.
