### PR TITLE
Fix compiler warnings

### DIFF
--- a/examples/broadcast.rs
+++ b/examples/broadcast.rs
@@ -3,7 +3,6 @@ extern crate timely_communication;
 
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
-use timely_communication::allocator::Allocate;
 
 fn main() {
     timely::execute_from_args(std::env::args().skip(1), move |root| {

--- a/examples/unordered_input.rs
+++ b/examples/unordered_input.rs
@@ -3,7 +3,7 @@ extern crate timely_communication;
 
 use timely::dataflow::operators::*;
 use timely_communication::Configuration;
-use timely::dataflow::{Stream, Scope};
+use timely::dataflow::Scope;
 use timely::progress::timestamp::RootTimestamp;
 
 fn main() {

--- a/src/dataflow/channels/pushers/buffer.rs
+++ b/src/dataflow/channels/pushers/buffer.rs
@@ -39,7 +39,7 @@ impl<T, D, P: Push<(T, Content<D>)>> Buffer<T, D, P> where T: Eq+Clone {
         self.time = Some(cap.time());
         AutoflushSession {
             buffer: self,
-            capability: cap,
+            _capability: cap,
         }
     }
 
@@ -131,7 +131,7 @@ pub struct AutoflushSession<'a, T: Timestamp, D, P: Push<(T, Content<D>)>+'a> wh
     /// A reference to the underlying buffer.
     buffer: &'a mut Buffer<T, D, P>,
     /// The capability being used to send the data.
-    capability: Capability<T>,
+    _capability: Capability<T>,
 }
 
 impl<'a, T: Timestamp, D, P: Push<(T, Content<D>)>+'a> AutoflushSession<'a, T, D, P> where T: Eq+Clone+'a, D: 'a {

--- a/src/dataflow/operators/broadcast.rs
+++ b/src/dataflow/operators/broadcast.rs
@@ -11,7 +11,7 @@ use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use dataflow::channels::pushers::Tee;
 use dataflow::channels::pullers::Counter as PullCounter;
 use dataflow::channels::pact::{Pusher, Puller};
-use timely_communication::{Allocate};
+
 use std::rc::Rc;
 use std::cell::RefCell;
 

--- a/src/dataflow/operators/capture.rs
+++ b/src/dataflow/operators/capture.rs
@@ -69,7 +69,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::ops::DerefMut;
 
 use ::Data;

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
 
-use progress::frontier::{MutableAntichain, Antichain};
+use progress::frontier::Antichain;
 use progress::{Operate, Timestamp};
 use progress::nested::subgraph::Source;
 use progress::count_map::CountMap;

--- a/src/dataflow/operators/inspect.rs
+++ b/src/dataflow/operators/inspect.rs
@@ -30,7 +30,7 @@ pub trait Inspect<G: Scope, D: Data> {
     ///            .inspect_batch(|t,xs| println!("seen at: {:?}\t{:?} records", t, xs.len()));
     /// });
     /// ```
-    fn inspect_batch<F: FnMut(&G::Timestamp, &[D])+'static>(&self, mut func: F) -> Self;
+    fn inspect_batch<F: FnMut(&G::Timestamp, &[D])+'static>(&self, func: F) -> Self;
 }
 
 impl<G: Scope, D: Data> Inspect<G, D> for Stream<G, D> {

--- a/src/dataflow/operators/to_stream.rs
+++ b/src/dataflow/operators/to_stream.rs
@@ -9,8 +9,6 @@ use progress::{Operate, Timestamp};
 use progress::nested::subgraph::Source;
 use progress::count_map::CountMap;
 
-use timely_communication::Allocate;
-
 use Data;
 use dataflow::channels::Content;
 use dataflow::channels::pushers::{Tee, Counter};

--- a/src/dataflow/operators/unordered_input.rs
+++ b/src/dataflow/operators/unordered_input.rs
@@ -9,7 +9,6 @@ use progress::{Operate, Timestamp};
 use progress::nested::subgraph::Source;
 use progress::count_map::CountMap;
 
-use timely_communication::Allocate;
 use Data;
 use dataflow::channels::pushers::{Tee, Counter as PushCounter};
 use dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,7 +17,7 @@ use dataflow::operators::capture::{EventWriter, Event, EventPusher};
 
 use abomonation::Abomonation;
 
-static mut precise_time_ns_delta: Option<i64> = None;
+static mut PRECISE_TIME_NS_DELTA: Option<i64> = None;
 
 /// Returns the value of an high resolution performance counter, in nanoseconds, rebased to be
 /// roughly comparable to an unix timestamp.
@@ -25,7 +25,7 @@ static mut precise_time_ns_delta: Option<i64> = None;
 /// precision of the wall clock base; clock skew effects should be taken into consideration).
 #[inline(always)]
 fn get_precise_time_ns() -> u64 {
-    (time::precise_time_ns() as i64 - unsafe { precise_time_ns_delta.unwrap() }) as u64
+    (time::precise_time_ns() as i64 - unsafe { PRECISE_TIME_NS_DELTA.unwrap() }) as u64
 }
 
 /// Logs `record` in `logger` if logging is enabled.
@@ -119,7 +119,7 @@ pub fn initialize<A: Allocate>(root: &mut Root<A>) {
     GUARDED_PROGRESS.with(|x| x.set(File::create(format!("logs/guarded_progress-{}.abom", root.index())).unwrap()));
 
     unsafe {
-        precise_time_ns_delta = Some({
+        PRECISE_TIME_NS_DELTA = Some({
             let wall_time = time::get_time();
             let wall_time_ns = wall_time.nsec as i64 + wall_time.sec * 1000000000;
             time::precise_time_ns() as i64 - wall_time_ns

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,7 +13,6 @@ use ::progress::timestamp::RootTimestamp;
 use ::progress::nested::product::Product;
 
 use dataflow::scopes::root::Root;
-use dataflow::Scope;
 use dataflow::operators::capture::{EventWriter, Event, EventPusher};
 
 use abomonation::Abomonation;


### PR DESCRIPTION
Fixes a bunch of compiler warnings. The first one might become a hard error in the future, the rest are unused imports and some stylistic warnings.

There are still a couple of warning issued in the doctests, but many of them serve illustrative purposes in the examples (i.e. unused result for `let output = ...;`), so I didn't change these.