### PR TITLE
reworked data trait

### DIFF
--- a/examples/rc.rs
+++ b/examples/rc.rs
@@ -1,0 +1,40 @@
+extern crate abomonation;
+extern crate timely;
+
+use std::rc::Rc;
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use abomonation::Abomonation;
+
+#[derive(Debug, Clone)]
+pub struct Test {
+   field: Rc<usize>,
+}
+
+impl Abomonation for Test {
+   unsafe fn entomb(&self, _writer: &mut Vec<u8>) { panic!() }
+   unsafe fn embalm(&mut self) { panic!() }
+   unsafe fn exhume<'a,'b>(&'a mut self, _bytes: &'b mut [u8]) -> Option<&'b mut [u8]> { panic!()  }
+}
+
+fn main() {
+   // initializes and runs a timely dataflow computation
+   timely::execute_from_args(std::env::args(), |computation| {
+       // create a new input, exchange data, and inspect its output
+       let (mut input, probe) = computation.scoped(move |builder| {
+           let index = builder.index();
+           let (input, stream) = builder.new_input();
+           let probe = stream//.exchange(|x| *x)
+                           .inspect(move |x| println!("worker {}:\thello {:?}", index, x))
+                           .probe().0;
+           (input, probe)
+       });
+
+       // introduce data and watch!
+       for round in 0..10 {
+           input.send(Test { field: Rc::new(round) } );
+           input.advance_to(round + 1);
+           computation.step_while(|| probe.lt(input.time()));
+       }
+   }).unwrap();
+}

--- a/src/dataflow/operators/aggregation/aggregate.rs
+++ b/src/dataflow/operators/aggregation/aggregate.rs
@@ -2,7 +2,7 @@
 use std::hash::Hash;
 use std::collections::HashMap;
 
-use ::Data;
+use ::{Data, ExchangeData};
 use dataflow::{Stream, Scope};
 use dataflow::operators::unary::Unary;
 use dataflow::channels::pact::Exchange;
@@ -11,7 +11,7 @@ use dataflow::channels::pact::Exchange;
 /// 
 /// Extension method supporting aggregation of keyed data within timestamp. 
 /// For inter-timestamp aggregation, consider `StateMachine`.
-pub trait Aggregate<S: Scope, K: Data+Hash, V: Data> {
+pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
 	/// Aggregates data of the form `(key, val)`, using user-supplied logic.
 	///
 	/// The `aggregate` method is implemented for streams of `(K, V)` data, 
@@ -69,7 +69,7 @@ pub trait Aggregate<S: Scope, K: Data+Hash, V: Data> {
 	>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp : Hash+Eq;
 } 
 
-impl<S: Scope, K: Data+Hash+Eq, V: Data> Aggregate<S, K, V> for Stream<S, (K, V)> {
+impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, (K, V)> {
 
 		fn aggregate<
 			R: Data, 

--- a/src/dataflow/operators/aggregation/state_machine.rs
+++ b/src/dataflow/operators/aggregation/state_machine.rs
@@ -2,7 +2,7 @@
 use std::hash::Hash;
 use std::collections::HashMap;
 
-use ::Data;
+use ::{Data, ExchangeData};
 use dataflow::{Stream, Scope};
 use dataflow::operators::unary::Unary;
 use dataflow::channels::pact::Exchange;
@@ -17,7 +17,7 @@ use dataflow::channels::pact::Exchange;
 /// is some total order on times respecting the total order (updates may be interleaved).
 
 /// Provides the `state_machine` method.
-pub trait StateMachine<S: Scope, K: Data+Hash+Eq, V: Data> {
+pub trait StateMachine<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> {
     /// Tracks a state for each presented key, using user-supplied state transition logic.
     ///
     /// The transition logic `fold` may mutate the state, and produce both output records and 
@@ -54,7 +54,7 @@ pub trait StateMachine<S: Scope, K: Data+Hash+Eq, V: Data> {
     >(&self, fold: F, hash: H) -> Stream<S, R> where S::Timestamp : Hash+Eq ;
 } 
 
-impl<S: Scope, K: Data+Hash+Eq, V: Data> StateMachine<S, K, V> for Stream<S, (K, V)> {
+impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> for Stream<S, (K, V)> {
     fn state_machine<
             R: Data,                                    // output type
             D: Default+'static,                         // per-key state (data)

--- a/src/dataflow/operators/broadcast.rs
+++ b/src/dataflow/operators/broadcast.rs
@@ -1,6 +1,6 @@
 //! Broadcast records to all workers.
 
-use ::Data;
+use ::ExchangeData;
 use progress::nested::subgraph::{Source, Target};
 use dataflow::{Stream, Scope};
 use progress::count_map::CountMap;
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 /// Broadcast records to all workers.
-pub trait Broadcast<D: Data> {
+pub trait Broadcast<D: ExchangeData> {
     /// Broadcast records to all workers.
     ///
     /// #Examples
@@ -32,7 +32,7 @@ pub trait Broadcast<D: Data> {
     fn broadcast(&self) -> Self;
 }
 
-impl<G: Scope, D: Data> Broadcast<D> for Stream<G, D> {
+impl<G: Scope, D: ExchangeData> Broadcast<D> for Stream<G, D> {
     fn broadcast(&self) -> Stream<G, D> {
         let mut scope = self.scope();
 
@@ -63,14 +63,14 @@ impl<G: Scope, D: Data> Broadcast<D> for Stream<G, D> {
     }
 }
 
-struct BroadcastOperator<T: Timestamp, D: Data> {
+struct BroadcastOperator<T: Timestamp, D: ExchangeData> {
     index: usize,
     peers: usize,
     input: PullCounter<T, D>,
     output: PushBuffer<T, D, PushCounter<T, D, Tee<T, D>>>,
 }
 
-impl<T: Timestamp, D: Data> Operate<T> for BroadcastOperator<T, D> {
+impl<T: Timestamp, D: ExchangeData> Operate<T> for BroadcastOperator<T, D> {
     fn name(&self) -> String { "Broadcast".to_owned() }
     fn inputs(&self) -> usize { self.peers }
     fn outputs(&self) -> usize { 1 }

--- a/src/dataflow/operators/exchange.rs
+++ b/src/dataflow/operators/exchange.rs
@@ -1,12 +1,12 @@
 //! Exchange records between workers.
 
-use ::Data;
+use ::ExchangeData;
 use dataflow::channels::pact::Exchange as ExchangePact;
 use dataflow::{Stream, Scope};
 use dataflow::operators::unary::Unary;
 
 /// Exchange records between workers.
-pub trait Exchange<D: Data> {
+pub trait Exchange<D: ExchangeData> {
     /// Exchange records so that all records with the same `route` are at the same worker.
     ///
     /// #Examples
@@ -22,7 +22,7 @@ pub trait Exchange<D: Data> {
     fn exchange<F: Fn(&D)->u64+'static>(&self, route: F) -> Self;
 }
 
-impl<G: Scope, D: Data> Exchange<D> for Stream<G, D> {
+impl<G: Scope, D: ExchangeData> Exchange<D> for Stream<G, D> {
     fn exchange<F: Fn(&D)->u64+'static>(&self, route: F) -> Stream<G, D> {
         self.unary_stream(ExchangePact::new(route), "Exchange", |input, output| {
             input.for_each(|time, data| {

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -62,11 +62,11 @@ pub trait Input<'a, A: Allocate, T: Timestamp+Ord> {
     ///     }
     /// });
     /// ```
-    fn new_input<D:Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>);
+    fn new_input<D: Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>);
 }
 
 impl<'a, A: Allocate, T: Timestamp+Ord> Input<'a, A, T> for Child<'a, Root<A>, T> {
-    fn new_input<D:Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>) {
+    fn new_input<D: Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>) {
 
         let (output, registrar) = Tee::<Product<RootTimestamp, T>, D>::new();
         let produced = Rc::new(RefCell::new(CountMap::new()));

--- a/src/dataflow/operators/unary.rs
+++ b/src/dataflow/operators/unary.rs
@@ -168,7 +168,8 @@ Operator<T, D1, D2, L> {
 
 impl<T, D1, D2, L> Operate<T> for Operator<T, D1, D2, L>
 where T: Timestamp,
-      D1: Data, D2: Data,
+      D1: Data, 
+      D2: Data,
       L: FnMut(&mut InputHandle<T, D1>,
                &mut OutputHandle<T, D2, Tee<T, D2>>,
                &mut Notificator<T>) {

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -6,7 +6,7 @@
 
 use progress::nested::subgraph::{Source, Target};
 
-use {Data, Push};
+use Push;
 use dataflow::Scope;
 use dataflow::channels::pushers::tee::TeeHelper;
 use dataflow::channels::Content;
@@ -18,7 +18,7 @@ use dataflow::channels::Content;
 /// Internally `Stream` maintains a list of data recipients who should be presented with data
 /// produced by the source of the stream.
 #[derive(Clone)]
-pub struct Stream<S: Scope, D:Data> {
+pub struct Stream<S: Scope, D> {
     /// The progress identifier of the stream's data source.
     name: Source,
     /// The `Scope` containing the stream.
@@ -27,7 +27,7 @@ pub struct Stream<S: Scope, D:Data> {
     ports: TeeHelper<S::Timestamp, D>,
 }
 
-impl<S: Scope, D:Data> Stream<S, D> {
+impl<S: Scope, D> Stream<S, D> {
     /// Connects the stream to a destination.
     ///
     /// The destination is described both by a `Target`, for progress tracking information, and a `P: Push` where the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,20 @@ pub mod execute;
 // #[cfg(feature = "logging")]
 pub mod logging;
 
-/// A composite trait for types usable in timely dataflow.
-pub trait Data: timely_communication::Data + abomonation::Abomonation { }
-impl<T: timely_communication::Data+abomonation::Abomonation> Data for T { }
+/// A composite trait for types usable as data in timely dataflow.
+///
+/// The `Data` trait is necessary for all types that go along timely dataflow channels.
+pub trait Data: ::abomonation::Abomonation+Clone+'static { }
+impl<T: ::abomonation::Abomonation+Clone+'static> Data for T { }
+
+/// A composite trait for types usable on exchange channels in timely dataflow.
+///
+/// The `ExchangeData` trait extends `Data` with any requirements imposed by the `timely_communication` 
+/// `Data` trait, which describes requirements for communication along channels. 
+pub trait ExchangeData: Data + timely_communication::Data { }
+impl<T: Data + timely_communication::Data> ExchangeData for T { }
+
+
+// /// A composite trait for types usable in timely dataflow.
+// pub trait Data: timely_communication::Data + abomonation::Abomonation { }
+// impl<T: timely_communication::Data+abomonation::Abomonation> Data for T { }


### PR DESCRIPTION
This PR changes the `Data` trait from the most conservative requirements (serialization and `Send`), to much more permissive requirements (`Clone+Abomonation+'static`, where the `Abomonation` requirement should go away). The PR also introduces the `ExchangeData` trait, which is essentially the old `Data`, describing sufficient traits for a type to be used in an exchange channel.

The intent of the change is to allow types that may not implement `Send`, for example types containing an `Rc`, to still be used in timely dataflow as long as they are not used along exchange edges. For example, the following program (now `examples/rc.rs`) allows the use of an `Rc` type, although we have to fake out an `Abomonation` implementation.

```rust
extern crate abomonation;
extern crate timely;

use std::rc::Rc;
use timely::dataflow::*;
use timely::dataflow::operators::*;
use abomonation::Abomonation;

#[derive(Debug, Clone)]
pub struct Test {
   field: Rc<usize>,
}

impl Abomonation for Test {
   unsafe fn entomb(&self, _writer: &mut Vec<u8>) { panic!() }
   unsafe fn embalm(&mut self) { panic!() }
   unsafe fn exhume<'a,'b>(&'a mut self, _bytes: &'b mut [u8]) -> Option<&'b mut [u8]> { panic!()  }
}

fn main() {
   // initializes and runs a timely dataflow computation
   timely::execute_from_args(std::env::args(), |computation| {
       // create a new input, exchange data, and inspect its output
       let (mut input, probe) = computation.scoped(move |builder| {
           let index = builder.index();
           let (input, stream) = builder.new_input();
           let probe = stream//.exchange(|x| *x)
                           .inspect(move |x| println!("worker {}:\thello {:?}", index, x))
                           .probe().0;
           (input, probe)
       });

       // introduce data and watch!
       for round in 0..10 {
           input.send(Test { field: Rc::new(round) } );
           input.advance_to(round + 1);
           computation.step_while(|| probe.lt(input.time()));
       }
   }).unwrap();
}
```

The requirement of `Abomonation` will ideally go away, but for the moment is required because the internal datastructures for record batching (`dataflow/channels/message.rs`) require a method for serialization and deserialization. In the future, it makes sense to have the `Data` trait indicate a `Batch` associated type, once we identify the sufficient functions.