### PR TITLE
Refactor timely-sort

### DIFF
--- a/sort/src/batched_vec.rs
+++ b/sort/src/batched_vec.rs
@@ -68,17 +68,17 @@ impl<'a, T> BatchedVecRef<'a, T> {
     }
 
     #[inline(always)]
-    pub fn finish_into(&mut self, target: &mut Vec<Vec<T>>, stash: &mut Stash<T>) {
+    pub fn finish_into(&mut self, target: &mut Vec<Vec<T>>) {
         target.extend(self.batches.drain(..));
         if !self.tail.is_empty() {
-            target.push(mem::replace(&mut self.tail, stash.get()));
+            target.push(mem::replace(&mut self.tail, Vec::new()));
         }
     }
 
     #[inline(always)]
-    pub fn finish(&mut self, stash: &mut Stash<T>) -> Vec<Vec<T>> {
+    pub fn finish(&mut self) -> Vec<Vec<T>> {
         if !self.tail.is_empty() {
-            self.batches.push(mem::replace(&mut self.tail, stash.get()));
+            self.batches.push(mem::replace(&mut self.tail, Vec::new()));
         }
         mem::replace(&mut self.batches, Vec::new())
     }

--- a/sort/src/batched_vec.rs
+++ b/sort/src/batched_vec.rs
@@ -1,0 +1,99 @@
+use std::{mem, ptr};
+use stash::Stash;
+
+pub struct BatchedVecRef<'a, T: 'a> {
+    tail: &'a mut Vec<T>,
+    batches: &'a mut Vec<Vec<T>>
+}
+
+impl<'a, T> BatchedVecRef<'a, T> {
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        // It is sufficent to only check the tail for emptiness, since any time we flush
+        // the tail (in .reserve), we also push some elements.
+        self.tail.is_empty()
+    }
+
+    #[inline(always)]
+    fn reserve(&mut self, stash: &mut Stash<T>) {
+        if self.tail.len() == self.tail.capacity() {
+            let complete = mem::replace(self.tail, stash.get());
+            if !complete.is_empty() {
+                self.batches.push(complete);
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn push(&mut self, element: T, stash: &mut Stash<T>) {
+        self.reserve(stash);
+
+        // The reserve call already ensured we have space. For
+        // efficiency, use an unchecked push.
+        unsafe {
+            let len = self.tail.len();
+            ptr::write(self.tail.get_unchecked_mut(len), element);
+            self.tail.set_len(len + 1);
+        }
+    }
+
+    #[inline(always)]
+    pub unsafe fn push_all(&mut self, elements: &[T], stash: &mut Stash<T>) {
+        self.reserve(stash);
+
+        if !(self.tail.capacity() - self.tail.len() >= elements.len()) {
+            panic!("cap: {:?}, len: {:?}, pcl: {:?}", self.tail.capacity(), self.tail.len(), elements.len());
+        }
+
+        let len = self.tail.len();
+        ptr::copy_nonoverlapping(elements.as_ptr(), self.tail.as_mut_ptr().offset(len as isize), elements.len());
+        self.tail.set_len(len + elements.len());
+    }
+
+    #[inline(always)]
+    pub fn finish_into(&mut self, target: &mut Vec<Vec<T>>, stash: &mut Stash<T>) {
+        target.extend(self.batches.drain(..));
+        if !self.tail.is_empty() {
+            target.push(mem::replace(&mut self.tail, stash.get()));
+        }
+    }
+
+    #[inline(always)]
+    pub fn finish(&mut self, stash: &mut Stash<T>) -> Vec<Vec<T>> {
+        if !self.tail.is_empty() {
+            self.batches.push(mem::replace(&mut self.tail, stash.get()));
+        }
+        mem::replace(&mut self.batches, Vec::new())
+    }
+}
+
+pub struct BatchedVecX256<T> {
+    tails: Vec<Vec<T>>,
+    batches: Vec<Vec<Vec<T>>>
+}
+
+impl<T> BatchedVecX256<T> {
+    pub fn new() -> BatchedVecX256<T> {
+        let mut tails = Vec::with_capacity(256);
+        let mut batches = Vec::with_capacity(256);
+        for _byte in 0..256 {
+            tails.push(Vec::new());
+            batches.push(Vec::new());
+        }
+
+        BatchedVecX256 {
+            tails: tails,
+            batches: batches
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self, byte: u8) -> BatchedVecRef<T> {
+        unsafe {
+            BatchedVecRef {
+                tail: self.tails.get_unchecked_mut(byte as usize),
+                batches: self.batches.get_unchecked_mut(byte as usize)
+            }
+        }
+    }
+}

--- a/sort/src/lib.rs
+++ b/sort/src/lib.rs
@@ -1,6 +1,7 @@
 mod lsb;
 mod lsb_swc;
 mod msb;
+mod stash;
 
 pub use lsb::RadixSorter as LSBRadixSorter;
 pub use lsb_swc::RadixSorter as LSBSWCRadixSorter;

--- a/sort/src/lib.rs
+++ b/sort/src/lib.rs
@@ -2,6 +2,7 @@ mod lsb;
 mod lsb_swc;
 mod msb;
 mod stash;
+mod batched_vec;
 
 pub use lsb::RadixSorter as LSBRadixSorter;
 pub use lsb_swc::RadixSorter as LSBSWCRadixSorter;

--- a/sort/src/lsb.rs
+++ b/sort/src/lsb.rs
@@ -131,7 +131,7 @@ impl<T> RadixShuffler<T> {
     /// Finishes the shuffling into a target vector.
     fn finish_into(&mut self, target: &mut Vec<Vec<T>>) {
         for byte in 0..256 {
-            self.buckets.get_mut(byte as u8).finish_into(target, &mut self.stash);
+            self.buckets.get_mut(byte as u8).finish_into(target);
         }
     }
 }

--- a/sort/src/lsb_swc.rs
+++ b/sort/src/lsb_swc.rs
@@ -1,5 +1,8 @@
+use std::slice;
+
 use ::Unsigned;
 use stash::Stash;
+use batched_vec::BatchedVecX256;
 
 macro_rules! per_cache_line {
     ($t:ty) => {{ ::std::cmp::max(64 / ::std::mem::size_of::<$t>(), 4) }}
@@ -91,17 +94,12 @@ pub struct RadixShuffler<T> {
     staged: Vec<T>,     // ideally: 256 * number of T element per cache line.
     counts: [u8; 256],
 
-    fronts: Vec<Vec<T>>,
-    buffers: Vec<Vec<Vec<T>>>, // for each byte, a list of segments
-
+    buckets: BatchedVecX256<T>,
     stash: Stash<T>,      // spare segments
 }
 
 impl<T> RadixShuffler<T> {
     fn new() -> RadixShuffler<T> {
-        let mut buffers = vec![]; for _ in 0..256 { buffers.push(Vec::new()); }
-        let mut fronts = vec![]; for _ in 0..256 { fronts.push(Vec::new()); }
-
         let staged = Vec::with_capacity(256 * per_cache_line!(T));
 
         // looks like this is often cache-line aligned; yay!
@@ -111,8 +109,7 @@ impl<T> RadixShuffler<T> {
         RadixShuffler {
             staged: staged,
             counts: [0; 256],
-            buffers: buffers,
-            fronts: fronts,
+            buckets: BatchedVecX256::new(),
             stash: Stash::new(lines_per_page!() * per_cache_line!(T)),
         }
     }
@@ -128,41 +125,27 @@ impl<T> RadixShuffler<T> {
     #[inline]
     fn push<F: Fn(&T)->u8>(&mut self, element: T, function: &F) {
 
-        let byte = function(&element) as usize;
+        let byte = function(&element);
 
         // write the element to our scratch buffer space and consider it taken care of.
         unsafe {
 
             // if we have saturated the buffer for byte, flush it out
-            if *self.counts.get_unchecked(byte) as usize == per_cache_line!(T) {
+            if *self.counts.get_unchecked(byte as usize) as usize == per_cache_line!(T) {
+                let staged_elements = slice::from_raw_parts(
+                    self.staged.as_ptr().offset(per_cache_line!(T) as isize * byte as isize),
+                    per_cache_line!(T)
+                );
 
-                if self.fronts.get_unchecked(byte).len() == self.fronts.get_unchecked(byte).capacity() {
-                    let complete = ::std::mem::replace(&mut self.fronts[byte], self.stash.get());
-                    if complete.len() > 0 {
-                        self.buffers[byte].push(complete);
-                    }
-                }
+                self.buckets.get_mut(byte).push_all(staged_elements, &mut self.stash);
 
-                // the position we will write to
-
-                if !(self.fronts[byte].capacity() - self.fronts[byte].len() >= per_cache_line!(T)) {
-                    panic!("cap: {:?}, len: {:?}, pcl: {:?}", self.fronts[byte].capacity(), self.fronts[byte].len(), per_cache_line!(T));
-                }
-                let front_len = self.fronts.get_unchecked(byte).len();
-                ::std::ptr::copy_nonoverlapping(self.staged.as_ptr().offset(per_cache_line!(T) as isize * byte as isize),
-                                                self.fronts[byte].as_mut_ptr().offset(front_len as isize),
-                                                per_cache_line!(T));
-
-                self.fronts.get_unchecked_mut(byte).set_len(front_len + per_cache_line!(T));
-
-                // assert!(self.fronts.get_unchecked(byte).capacity() == lines_per_page!() * per_cache_line!(T));
-                self.counts[byte] = 0;
+                self.counts[byte as usize] = 0;
             }
 
             // self.staged[byte * stride + self.counts[byte]] = element; self.counts[byte] += 1
-            let offset = per_cache_line!(T) as isize * byte as isize + *self.counts.get_unchecked(byte) as isize;
+            let offset = per_cache_line!(T) as isize * byte as isize + *self.counts.get_unchecked(byte as usize) as isize;
             ::std::ptr::write(self.staged.as_mut_ptr().offset(offset), element);
-            *self.counts.get_unchecked_mut(byte) += 1;
+            *self.counts.get_unchecked_mut(byte as usize) += 1;
         }
     }
 
@@ -173,11 +156,7 @@ impl<T> RadixShuffler<T> {
         // If there is room, we just copy them into the buffer, potentially saving on allocation churn.
 
         for byte in 0..256 {
-            target.extend(self.buffers[byte].drain(..));
-            if self.fronts[byte].len() > 0 {
-                let complete = ::std::mem::replace(&mut self.fronts[byte], Vec::new());
-                target.push(complete);
-            }
+            self.buckets.get_mut(byte as u8).finish_into(target, &mut self.stash);
 
             if target.last().map(|x| x.capacity() - x.len() >= self.counts[byte] as usize) != Some(true) {
                 target.push(self.stash.get());

--- a/sort/src/lsb_swc.rs
+++ b/sort/src/lsb_swc.rs
@@ -156,7 +156,7 @@ impl<T> RadixShuffler<T> {
         // If there is room, we just copy them into the buffer, potentially saving on allocation churn.
 
         for byte in 0..256 {
-            self.buckets.get_mut(byte as u8).finish_into(target, &mut self.stash);
+            self.buckets.get_mut(byte as u8).finish_into(target);
 
             if target.last().map(|x| x.capacity() - x.len() >= self.counts[byte] as usize) != Some(true) {
                 target.push(self.stash.get());

--- a/sort/src/msb.rs
+++ b/sort/src/msb.rs
@@ -70,7 +70,7 @@ impl<T> RadixSorter<T> {
         for byte in (0 .. 256).rev() {
             let mut bucket = self.buckets.get_mut(byte as u8); 
             if !bucket.is_empty() {
-                self.work.push((depth, bucket.finish(&mut self.stash)));
+                self.work.push((depth, bucket.finish()));
             }
         }
 
@@ -78,7 +78,7 @@ impl<T> RadixSorter<T> {
             self.ingest(&mut list, &bytes, depth, &action);
         }
 
-        self.done.ref_mut().finish(&mut self.stash)
+        self.done.ref_mut().finish()
     }
 
     pub fn recycle(&mut self, mut buffers: Vec<Vec<T>>) {
@@ -101,7 +101,7 @@ impl<T> RadixSorter<T> {
             self.ingest(&mut list, &bytes, depth, &action);
         }
 
-        self.done.ref_mut().finish_into(source, &mut self.stash);
+        self.done.ref_mut().finish_into(source);
     }
 
     // digests a list of batches, which we assume (for some reason) to be densely packed.
@@ -130,7 +130,7 @@ impl<T> RadixSorter<T> {
                 for byte in (0 .. 256).rev() {
                     let mut bucket = self.buckets.get_mut(byte as u8);
                     if !bucket.is_empty() {
-                        self.work.push((depth, bucket.finish(&mut self.stash)));
+                        self.work.push((depth, bucket.finish()));
                     }
                 }
             }

--- a/sort/src/stash.rs
+++ b/sort/src/stash.rs
@@ -1,0 +1,35 @@
+pub struct Stash<T> {
+    stashed: Vec<Vec<T>>,
+    default_capacity: usize
+}
+
+impl<T> Stash<T> {
+    pub fn new(default_capacity: usize) -> Stash<T> {
+        Stash {
+            stashed: Vec::new(),
+            default_capacity: default_capacity
+        }
+    }
+
+    pub fn get(&mut self) -> Vec<T> {
+        self.stashed.pop().unwrap_or_else(|| Vec::with_capacity(self.default_capacity))
+    }
+
+    pub fn give(&mut self, vec: Vec<T>) {
+        // TODO: determine some discipline for when to keep buffers vs not.
+        // if vec.capacity() == self.default_capacity {
+        self.stashed.push(vec);
+        // }
+    }
+
+    pub fn rebalance(&mut self, buffers: &mut Vec<Vec<T>>, intended: usize) {
+        while self.stashed.len() > intended {
+            buffers.push(self.stashed.pop().unwrap());
+        }
+        while self.stashed.len() < intended && buffers.len() > 0 {
+            let mut buffer = buffers.pop().unwrap();
+            buffer.clear();
+            self.stashed.push(buffer);
+        }
+    }
+}


### PR DESCRIPTION
A good chunk of the complexity in `timely-sort` relates to small details of memory management - specifically, managing a collection of reusable buffers and using batches of `Vec`s instead of a simple `Vec`. This pulls out much of that logic, which is shared between the different sorting algorithms.

In a number of cases, optimizations were inconsistently applied between the algorithms, so standardizing improves performance.