### PR TITLE
Implement TimeExchange PACT and extend Exchange operator

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,2 @@
 Contributions by Andrea Lattuada <andreal@student.ethz.ch> are Copyright (c) 2016 Andrea Lattuada, ETH Zürich.
+Contributions by Moritz Hoffmann <moritz.hoffmann@inf.ethz.ch> are Copyright (c) 2017 Moritz Hoffmann, ETH Zürich.

--- a/src/dataflow/channels/pact.rs
+++ b/src/dataflow/channels/pact.rs
@@ -28,7 +28,7 @@ impl<T: 'static, D: 'static> ParallelizationContract<T, D> for Pipeline {
     }
 }
 
-/// An exchange between multiple observers
+/// An exchange between multiple observers by data
 pub struct Exchange<D, F: Fn(&D)->u64+'static> { hash_func: F, phantom: PhantomData<D>, }
 impl<D, F: Fn(&D)->u64> Exchange<D, F> {
     /// Allocates a new `Exchange` pact from a distribution function.
@@ -51,10 +51,10 @@ impl<T: Eq+Data+Abomonation, D: Data+Abomonation, F: Fn(&D)->u64+'static> Parall
     }
 }
 
-/// An exchange between multiple observers
+/// An exchange between multiple observers by time and data
 pub struct TimeExchange<D, T, F: Fn(&T, &D)->u64+'static> { hash_func: F, phantom: PhantomData<(T, D)>, }
 impl<D, T, F: Fn(&T, &D)->u64> TimeExchange<D, T, F> {
-    /// Allocates a new `Exchange` pact from a distribution function.
+    /// Allocates a new `TimeExchange` pact from a distribution function.
     pub fn new(func: F) -> TimeExchange<D, T, F> {
         TimeExchange {
             hash_func:  func,

--- a/src/dataflow/channels/pact.rs
+++ b/src/dataflow/channels/pact.rs
@@ -52,14 +52,13 @@ impl<T: Eq+Data+Abomonation, D: Data+Abomonation, F: Fn(&D)->u64+'static> Parall
 }
 
 /// An exchange between multiple observers
-pub struct TimeExchange<D, T, F: Fn(&T, &D)->u64+'static> { hash_func: F, phantom: PhantomData<D>, phantom_t: PhantomData<T>, }
+pub struct TimeExchange<D, T, F: Fn(&T, &D)->u64+'static> { hash_func: F, phantom: PhantomData<(T, D)>, }
 impl<D, T, F: Fn(&T, &D)->u64> TimeExchange<D, T, F> {
     /// Allocates a new `Exchange` pact from a distribution function.
     pub fn new(func: F) -> TimeExchange<D, T, F> {
         TimeExchange {
             hash_func:  func,
             phantom:    PhantomData,
-            phantom_t:  PhantomData,
         }
     }
 }

--- a/src/dataflow/channels/pushers/exchange.rs
+++ b/src/dataflow/channels/pushers/exchange.rs
@@ -6,14 +6,14 @@ use abomonation::Abomonation;
 
 // TODO : Software write combining
 /// Distributes records among target pushees according to a distribution function.
-pub struct Exchange<T, D, P: Push<(T, Content<D>)>, H: Fn(&D) -> u64> {
+pub struct Exchange<T, D, P: Push<(T, Content<D>)>, H: Fn(&T, &D) -> u64> {
     pushers: Vec<P>,
     buffers: Vec<Vec<D>>,
     current: Option<T>,
     hash_func: H,
 }
 
-impl<T: Clone, D, P: Push<(T, Content<D>)>, H: Fn(&D)->u64>  Exchange<T, D, P, H> {
+impl<T: Clone, D, P: Push<(T, Content<D>)>, H: Fn(&T, &D)->u64>  Exchange<T, D, P, H> {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
     pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, D, P, H> {
         let mut buffers = vec![];
@@ -37,7 +37,7 @@ impl<T: Clone, D, P: Push<(T, Content<D>)>, H: Fn(&D)->u64>  Exchange<T, D, P, H
     }
 }
 
-impl<T: Eq+Clone+'static, D: Data+Abomonation, P: Push<(T, Content<D>)>, H: Fn(&D)->u64> Push<(T, Content<D>)> for Exchange<T, D, P, H> {
+impl<T: Eq+Clone+'static, D: Data+Abomonation, P: Push<(T, Content<D>)>, H: Fn(&T, &D)->u64> Push<(T, Content<D>)> for Exchange<T, D, P, H> {
     #[inline]
     fn push(&mut self, message: &mut Option<(T, Content<D>)>) {
         // if only one pusher, no exchange
@@ -59,7 +59,7 @@ impl<T: Eq+Clone+'static, D: Data+Abomonation, P: Push<(T, Content<D>)>, H: Fn(&
                 if (self.pushers.len() & (self.pushers.len() - 1)) == 0 {
                     let mask = (self.pushers.len() - 1) as u64;
                     for datum in data.drain(..) {
-                        let index = (((self.hash_func)(&datum)) & mask) as usize;
+                        let index = (((self.hash_func)(&time, &datum)) & mask) as usize;
 
                         self.buffers[index].push(datum);
                         if self.buffers[index].len() == self.buffers[index].capacity() {
@@ -78,7 +78,7 @@ impl<T: Eq+Clone+'static, D: Data+Abomonation, P: Push<(T, Content<D>)>, H: Fn(&
                 // as a last resort, use mod (%)
                 else {
                     for datum in data.drain(..) {
-                        let index = (((self.hash_func)(&datum)) % self.pushers.len() as u64) as usize;
+                        let index = (((self.hash_func)(&time, &datum)) % self.pushers.len() as u64) as usize;
                         self.buffers[index].push(datum);
                         if self.buffers[index].len() == self.buffers[index].capacity() {
                             self.flush(index);

--- a/src/dataflow/operators/exchange.rs
+++ b/src/dataflow/operators/exchange.rs
@@ -23,7 +23,8 @@ pub trait Exchange<T, D: ExchangeData> {
     /// ```
     fn exchange<F: Fn(&D)->u64+'static>(&self, route: F) -> Self;
 
-    /// Exchange records by time so that all records with the same `route` are at the same worker.
+    /// Exchange records by time so that all records whose time and data
+    /// evaluate to the same `route` are at the same worker.
     ///
     /// #Examples
     /// ```


### PR DESCRIPTION
Implement exchanging by time and data vs. by data only. This is useful to have permuting worker assignments for skewed data.

Signed-off-by: Moritz Hoffmann <moritz.hoffmann@inf.ethz.ch>