### PR TITLE
Replace PartialOrd with PartialOrder

### DIFF
--- a/src/dataflow/operators/aggregation/state_machine.rs
+++ b/src/dataflow/operators/aggregation/state_machine.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use ::{Data, ExchangeData};
+use order::PartialOrder;
 use dataflow::{Stream, Scope};
 use dataflow::operators::unary::Unary;
 use dataflow::channels::pact::Exchange;
@@ -71,7 +72,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> f
             // stash each input and request a notification when ready
             input.for_each(|time, data| {
                 // stash if not time yet
-                if notificator.frontier(0).iter().any(|x| x.lt(&time.time())) {
+                if notificator.frontier(0).iter().any(|x| x.less_than(&time.time())) {
                     pending.entry(time.time()).or_insert_with(Vec::new).extend(data.drain(..));
                     notificator.notify_at(time);
                 }

--- a/src/dataflow/operators/capability.rs
+++ b/src/dataflow/operators/capability.rs
@@ -24,9 +24,11 @@
 use std::ops::Deref;
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::fmt::{self, Debug};
+
+use order::PartialOrder;
 use progress::Timestamp;
 use progress::count_map::CountMap;
-use std::fmt::{self, Debug};
 
 /// A capability for timestamp `t` represents a permit for an operator that holds the capability
 /// to send data and request notifications at timestamp `t`.
@@ -46,7 +48,7 @@ impl<T: Timestamp> Capability<T> {
     /// the source capability (`self`).
     #[inline]
     pub fn delayed(&self, new_time: &T) -> Capability<T> {
-        assert!(new_time >= &self.time);
+        assert!(self.time.less_equal(new_time));
         mint(*new_time, self.internal.clone())
     }
 }

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -83,7 +83,7 @@ impl<TOuter: Timestamp, TInner: Timestamp, D: Data> Push<(Product<TOuter, TInner
     fn push(&mut self, message: &mut Option<(Product<TOuter, TInner>, Content<D>)>) {
         let active = if let Some((ref mut time, _)) = *message {
             time.inner = self.summary.results_in(&time.inner);
-            self.limit.ge(&time.inner)
+            time.inner.less_equal(&self.limit)
         }
         else { true };
 

--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -3,6 +3,8 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
+use order::PartialOrder;
+
 use progress::{Timestamp, Operate, Antichain};
 use progress::frontier::MutableAntichain;
 use progress::nested::subgraph::{Source, Target};
@@ -132,9 +134,9 @@ pub struct Handle<T:Timestamp> {
 
 impl<T: Timestamp> Handle<T> {
     /// returns true iff the frontier is strictly less than `time`.
-    #[inline] pub fn lt(&self, time: &T) -> bool { self.frontier.borrow().lt(time) }
+    #[inline] pub fn lt(&self, time: &T) -> bool { self.frontier.borrow().less_than(time) }
     /// returns true iff the frontier is less than or equal to `time`.
-    #[inline] pub fn le(&self, time: &T) -> bool { self.frontier.borrow().le(time) }
+    #[inline] pub fn le(&self, time: &T) -> bool { self.frontier.borrow().less_equal(time) }
     /// returns true iff the frontier is empty.
     #[inline] pub fn done(&self) -> bool { self.frontier.borrow().elements().len() == 0 }
     /// Allocates a new handle.

--- a/src/dataflow/operators/reclock.rs
+++ b/src/dataflow/operators/reclock.rs
@@ -1,6 +1,7 @@
 //! Extension methods for `Stream` based on record-by-record transformation.
 
 use Data;
+use order::PartialOrder;
 use dataflow::{Stream, Scope};
 use dataflow::channels::pact::Pipeline;
 use dataflow::operators::binary::Binary;
@@ -70,11 +71,11 @@ impl<S: Scope, D: Data> Reclock<S, D> for Stream<S, D> {
                 let time = cap.time();
                 let mut session = output.session(&cap);
                 for &mut (ref t, ref mut data) in &mut stash {
-                    if t.le(&time) {
+                    if t.less_equal(&time) {
                         session.give_content(data);
                     }
                 }
-                stash.retain(|x| !x.0.le(&time));
+                stash.retain(|x| !x.0.less_equal(&time));
             });
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,12 @@ extern crate time;
 
 pub use execute::{execute, execute_from_args, example};
 pub use timely_communication::{Push, Pull, Configuration};
+pub use order::PartialOrder;
 
 pub mod progress;
 pub mod dataflow;
 pub mod execute;
+pub mod order;
 
 // #[cfg(feature = "logging")]
 pub mod logging;

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,0 +1,29 @@
+//! Traits and types for partially ordered sets.
+
+/// A type that is partially ordered.
+///
+/// This trait is distinct from Rust's `PartialOrd` trait, because the implementation
+/// of that trait precludes a distinct `Ord` implementation. We need an independent 
+/// trait if we want to have a partially ordered type that can also be sorted.
+pub trait PartialOrder : Eq {
+    /// Returns true iff one element is strictly less than the other.
+    fn less_than(&self, other: &Self) -> bool {
+        self.less_equal(other) && self != other
+    }
+    /// Returns true iff one element is less than or equal to the other.
+    fn less_equal(&self, other: &Self) -> bool;
+}
+
+impl PartialOrder for u8 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for u16 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for u32 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for u64 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for usize { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+
+impl PartialOrder for i8 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for i16 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for i32 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for i64 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+impl PartialOrder for isize { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
+
+impl PartialOrder for () { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }

--- a/src/progress/nested/product.rs
+++ b/src/progress/nested/product.rs
@@ -1,8 +1,9 @@
 //! A pair timestamp suitable for use with the product partial order.
 
-use std::cmp::Ordering;
+// use std::cmp::Ordering;
 use std::fmt::{Formatter, Error, Debug};
 
+use order::PartialOrder;
 use progress::Timestamp;
 use progress::nested::summary::Summary;
 
@@ -12,7 +13,7 @@ use abomonation::Abomonation;
 ///
 /// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrd`,
 /// because Rust just uses the lexicographic total order.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Default, Ord)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub struct Product<TOuter, TInner> {
     /// Outer timestamp.
     pub outer: TOuter,
@@ -37,25 +38,31 @@ impl<TOuter: Debug, TInner: Debug> Debug for Product<TOuter, TInner> {
     }
 }
 
-impl<TOuter: PartialOrd, TInner: PartialOrd> PartialOrd for Product<TOuter, TInner> {
+impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter, TInner> {
     #[inline(always)]
-    fn partial_cmp(&self, other: &Product<TOuter, TInner>) -> Option<Ordering> {
-        match (self <= other, other <= self) {
-            (true, true)   => Some(Ordering::Equal),
-            (true, false)  => Some(Ordering::Less),
-            (false, true)  => Some(Ordering::Greater),
-            (false, false) => None,
-        }
-    }
-    #[inline(always)]
-    fn le(&self, other: &Product<TOuter, TInner>) -> bool {
-        self.inner <= other.inner && self.outer <= other.outer
-    }
-    #[inline(always)]
-    fn ge(&self, other: &Product<TOuter, TInner>) -> bool {
-        self.inner >= other.inner && self.outer >= other.outer
+    fn less_equal(&self, other: &Self) -> bool {
+        self.outer.less_equal(&other.outer) && self.inner.less_equal(&other.inner)
     }
 }
+// impl<TOuter: PartialOrd, TInner: PartialOrd> PartialOrd for Product<TOuter, TInner> {
+//     #[inline(always)]
+//     fn partial_cmp(&self, other: &Product<TOuter, TInner>) -> Option<Ordering> {
+//         match (self <= other, other <= self) {
+//             (true, true)   => Some(Ordering::Equal),
+//             (true, false)  => Some(Ordering::Less),
+//             (false, true)  => Some(Ordering::Greater),
+//             (false, false) => None,
+//         }
+//     }
+//     #[inline(always)]
+//     fn le(&self, other: &Product<TOuter, TInner>) -> bool {
+//         self.inner <= other.inner && self.outer <= other.outer
+//     }
+//     #[inline(always)]
+//     fn ge(&self, other: &Product<TOuter, TInner>) -> bool {
+//         self.inner >= other.inner && self.outer >= other.outer
+//     }
+// }
 
 impl<TOuter: Timestamp, TInner: Timestamp> Timestamp for Product<TOuter, TInner> {
     type Summary = Summary<TOuter::Summary, TInner::Summary>;

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -7,6 +7,8 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use timely_communication::Allocate;
 
+use order::PartialOrder;
+
 use progress::frontier::{MutableAntichain, Antichain};
 use progress::{Timestamp, PathSummary, Operate};
 
@@ -662,7 +664,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Subgraph<TOuter, TInner> {
     }
 }
 
-fn try_to_add_summary<T: Eq, S: PartialOrd+Eq+Copy+Debug>(vector: &mut Vec<(T, Antichain<S>)>, target: T, summary: S) -> bool {
+fn try_to_add_summary<T: Eq, S: PartialOrder+Eq+Copy+Debug>(vector: &mut Vec<(T, Antichain<S>)>, target: T, summary: S) -> bool {
     for &mut (ref t, ref mut antichain) in vector.iter_mut() {
         if target.eq(t) { return antichain.insert(summary); }
     }

--- a/src/progress/nested/summary.rs
+++ b/src/progress/nested/summary.rs
@@ -1,10 +1,11 @@
 //! Path summaries that are either child local, or leave the scope and re-enter from the parent.
 
-use std::cmp::Ordering;
+// use std::cmp::Ordering;
 use std::default::Default;
 use std::fmt::{Display, Formatter};
 use std::fmt::Error;
 
+use order::PartialOrder;
 use progress::{Timestamp, PathSummary};
 use progress::nested::product::Product;
 use progress::nested::summary::Summary::{Local, Outer};
@@ -25,20 +26,43 @@ impl<S, T: Default> Default for Summary<S, T> {
     fn default() -> Summary<S, T> { Local(Default::default()) }
 }
 
-impl<S:PartialOrd+Copy, T:PartialOrd+Copy> PartialOrd for Summary<S, T> {
-    #[inline]
-    fn partial_cmp(&self, other: &Summary<S, T>) -> Option<Ordering> {
-        // Two summaries are comparable if they are of the same type (Local, Outer).
-        // Otherwise, as Local *updates* and Outer *sets* the inner coordinate, we 
-        // cannot be sure that either strictly improves on the other.
+// Two summaries are comparable if they are the same type (Local or Outer). If they have different types, 
+// then there is no way to order them, as Local leaves the outer coordinate unincremented, and Outer has
+// a new inner coordinate that it installs, rather than advancing the existing inner coordinate.
+//
+// Two local summaries are ordered if their inner summaries are ordered.
+// 
+// Two outer summaries are ordered if their outer and inner summaries are ordered. 
+//
+// Note: I think the previous implementation, which compared (s1,t1) to (s2,t2), was incorrect. The order
+// on tuples is lexicographic, so this would put a small outer summary and large inner installment ahead
+// of a larger outer summary with small inner installment. I don't think that is correct (they should be
+// unordered.
+impl<S: PartialOrder+Copy, T: PartialOrder+Copy> PartialOrder for Summary<S, T> {
+    #[inline(always)]
+    fn less_equal(&self, other: &Self) -> bool {
         match (*self, *other) {
-            (Local(t1),    Local(t2))    => t1.partial_cmp(&t2),
-            (Outer(s1,t1), Outer(s2,t2)) => (s1,t1).partial_cmp(&(s2,t2)),
-            (Local(_),     Outer(_,_))   |
-            (Outer(_,_),   Local(_))     => None,
+            (Local(t1),    Local(t2))    => t1.less_equal(&t2),
+            (Outer(s1,t1), Outer(s2,t2)) => s1.less_equal(&s2) && t1.less_equal(&t2),
+            _  => false
         }
     }
 }
+
+// impl<S:PartialOrder+Copy, T:PartialOrder+Copy> PartialOrder for Summary<S, T> {
+//     #[inline]
+//     fn partial_cmp(&self, other: &Summary<S, T>) -> Option<Ordering> {
+//         // Two summaries are comparable if they are of the same type (Local, Outer).
+//         // Otherwise, as Local *updates* and Outer *sets* the inner coordinate, we 
+//         // cannot be sure that either strictly improves on the other.
+//         match (*self, *other) {
+//             (Local(t1),    Local(t2))    => t1.partial_cmp(&t2),
+//             (Outer(s1,t1), Outer(s2,t2)) => (s1,t1).partial_cmp(&(s2,t2)),
+//             (Local(_),     Outer(_,_))   |
+//             (Outer(_,_),   Local(_))     => None,
+//         }
+//     }
+// }
 
 impl<TOuter, SOuter, TInner, SInner> PathSummary<Product<TOuter, TInner>> for Summary<SOuter, SInner>
 where TOuter: Timestamp,

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -6,13 +6,14 @@ use std::default::Default;
 use std::fmt::Formatter;
 use std::fmt::Error;
 
+use order::PartialOrder;
 use progress::nested::product::Product;
 
 use abomonation::Abomonation;
 
 // TODO : Change Copy requirement to Clone;
 /// A composite trait for types that serve as timestamps in timely dataflow.
-pub trait Timestamp: Copy+Eq+PartialOrd+Default+Debug+Send+Any+Abomonation {
+pub trait Timestamp: Copy+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation {
     /// A type summarizing action on a timestamp along a dataflow path.
     type Summary : PathSummary<Self> + 'static;
 }
@@ -22,7 +23,7 @@ pub trait Timestamp: Copy+Eq+PartialOrd+Default+Debug+Send+Any+Abomonation {
 // TODO : This can be important when a summary would "overflow", as we want neither to overflow,
 // TODO : nor wrap around, nor saturate.
 /// A summary of how a timestamp advances along a timely dataflow path.
-pub trait PathSummary<T> : 'static+Copy+Eq+PartialOrd+Debug+Default {
+pub trait PathSummary<T> : 'static+Copy+Eq+PartialOrder+Debug+Default {
     /// Advances a timestamp according to the timestamp actions on the path.
     fn results_in(&self, src: &T) -> T;
     /// Composes this path summary with another path summary.
@@ -39,6 +40,8 @@ impl Debug for RootTimestamp {
         f.write_str("Root")
     }
 }
+
+impl PartialOrder for RootTimestamp { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }
 
 impl Abomonation for RootTimestamp { }
 impl RootTimestamp {
@@ -58,6 +61,9 @@ impl PathSummary<RootTimestamp> for RootSummary {
     #[inline]
     fn followed_by(&self, _: &RootSummary) -> RootSummary { RootSummary }
 }
+
+impl PartialOrder for RootSummary { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }
+
 
 impl Timestamp for () { type Summary = (); }
 impl PathSummary<()> for () {


### PR DESCRIPTION
This PR removes `PartialOrd` as the partial order basis for timestamps in timely dataflow. The trait is problematic in that it has an assumed semantic connection to `Ord`, in that they are assumed by the standard library to have the same implementation when they both exist, preventing a non-total order from implementing `Ord` and doing things like sort-dedup.

Most of the changes here are straightforward, with methods `less_than` and `less_equal` replacing `lt` and `le`. There is a bit of annoying auditing to do, as most timestamp types still derive `Ord` (otherwise they could never be sorted), meaning they have access to `lt` and `le`, and code which uses it as the partial order comparison will not be correct. The `Timestamp` trait does not require `Ord` though, so writing methods generically with `T: Timestamp` should reveal uses of `lt` and `le`.