### PR TITLE
Summary options

### DIFF
--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -19,7 +19,7 @@ fn main() {
                 vec![RootTimestamp::new(0)],
                 move |_, _, notificator| {
                     while let Some((cap, _count)) = notificator.next() {
-                        let mut time = cap.time();
+                        let mut time = cap.time().clone();
                         time.inner += 1;
                         if time.inner < iterations {
                             notificator.notify_at(cap.delayed(&time));

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -66,7 +66,7 @@ fn main() {
 
                     // receive (node, worker) pairs, note any new ones.
                     input2.for_each(|time, data| {
-                        node_lists.entry(time.time())
+                        node_lists.entry(time.time().clone())
                                   .or_insert_with(|| {
                                       notify.notify_at(time.clone());
                                       Vec::new()

--- a/examples/distinct.rs
+++ b/examples/distinct.rs
@@ -13,7 +13,7 @@ fn main() {
             .to_stream(scope)
             .unary_stream(Pipeline, "Distinct", move |input, output| {
                 input.for_each(|time, data| {
-                    let mut counts = counts_by_time.entry(time.time())
+                    let mut counts = counts_by_time.entry(time.time().clone())
                                                    .or_insert(HashMap::new());
                     let mut session = output.session(&time);
                     for &datum in data.iter() {

--- a/src/dataflow/channels/pushers/buffer.rs
+++ b/src/dataflow/channels/pushers/buffer.rs
@@ -35,8 +35,8 @@ impl<T, D, P: Push<(T, Content<D>)>> Buffer<T, D, P> where T: Eq+Clone {
     }
     /// Allocates a new `AutoflushSession` which flushes itself on drop.
     pub fn autoflush_session(&mut self, cap: Capability<T>) -> AutoflushSession<T, D, P> where T: Timestamp {
-        if let Some(true) = self.time.as_ref().map(|x| *x != cap.time()) { self.flush(); }
-        self.time = Some(cap.time());
+        if let Some(true) = self.time.as_ref().map(|x| x != cap.time()) { self.flush(); }
+        self.time = Some(cap.time().clone());
         AutoflushSession {
             buffer: self,
             _capability: cap,

--- a/src/dataflow/operators/aggregation/aggregate.rs
+++ b/src/dataflow/operators/aggregation/aggregate.rs
@@ -85,7 +85,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for 
 
 			// read each input, fold into aggregates
 			input.for_each(|time, data| {
-				let agg_time = aggregates.entry(time.time()).or_insert_with(HashMap::new);
+				let agg_time = aggregates.entry(time.time().clone()).or_insert_with(HashMap::new);
 				for (key, val) in data.drain(..) {
 					let agg = agg_time.entry(key.clone()).or_insert_with(Default::default);
 					fold(&key, val, agg);

--- a/src/dataflow/operators/aggregation/state_machine.rs
+++ b/src/dataflow/operators/aggregation/state_machine.rs
@@ -73,7 +73,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> f
             input.for_each(|time, data| {
                 // stash if not time yet
                 if notificator.frontier(0).iter().any(|x| x.less_than(&time.time())) {
-                    pending.entry(time.time()).or_insert_with(Vec::new).extend(data.drain(..));
+                    pending.entry(time.time().clone()).or_insert_with(Vec::new).extend(data.drain(..));
                     notificator.notify_at(time);
                 }
                 else {
@@ -92,7 +92,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> f
 
             // go through each time with data, process each (key, val) pair.
             notificator.for_each(|time,_,_| {
-                if let Some(pend) = pending.remove(&time.time()) {
+                if let Some(pend) = pending.remove(time.time()) {
                     let mut session = output.session(&time);
                     for (key, val) in pend {
                         let (remove, output) = {

--- a/src/dataflow/operators/capability.rs
+++ b/src/dataflow/operators/capability.rs
@@ -26,7 +26,6 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
 
-use order::PartialOrder;
 use progress::Timestamp;
 use progress::count_map::CountMap;
 

--- a/src/dataflow/operators/capability.rs
+++ b/src/dataflow/operators/capability.rs
@@ -39,8 +39,8 @@ pub struct Capability<T: Timestamp> {
 impl<T: Timestamp> Capability<T> {
     /// The timestamp associated with this capability.
     #[inline]
-    pub fn time(&self) -> T {
-        self.time
+    pub fn time(&self) -> &T {
+        &self.time
     }
 
     /// Makes a new capability for a timestamp `new_time` greater or equal to the timestamp of
@@ -48,7 +48,7 @@ impl<T: Timestamp> Capability<T> {
     #[inline]
     pub fn delayed(&self, new_time: &T) -> Capability<T> {
         assert!(self.time.less_equal(new_time));
-        mint(*new_time, self.internal.clone())
+        mint(new_time.clone(), self.internal.clone())
     }
 }
 
@@ -74,7 +74,7 @@ impl<T: Timestamp> Drop for Capability<T> {
 
 impl<T: Timestamp> Clone for Capability<T> {
     fn clone(&self) -> Capability<T> {
-        mint(self.time, self.internal.clone())
+        mint(self.time.clone(), self.internal.clone())
     }
 }
 

--- a/src/dataflow/operators/capability.rs
+++ b/src/dataflow/operators/capability.rs
@@ -26,11 +26,16 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
 
+use order::PartialOrder;
 use progress::Timestamp;
 use progress::count_map::CountMap;
 
-/// A capability for timestamp `t` represents a permit for an operator that holds the capability
-/// to send data and request notifications at timestamp `t`.
+/// The capability to send data with a certain timestamp on a dataflow edge.
+///
+/// Capabilities are used by timely dataflow's progress tracking machinery to restrict and track
+/// when user code retains the ability to send messages on dataflow edges. All capabilities are
+/// constructed by the system, and should eventually be dropped by the user. Failure to drop 
+/// a capability (for whatever reason) will cause timely dataflow's progress tracking to stall.
 pub struct Capability<T: Timestamp> {
     time: T,
     internal: Rc<RefCell<CountMap<T>>>,
@@ -45,10 +50,23 @@ impl<T: Timestamp> Capability<T> {
 
     /// Makes a new capability for a timestamp `new_time` greater or equal to the timestamp of
     /// the source capability (`self`).
+    ///
+    /// This method panics if `self.time` is not less or equal to `new_time`.
     #[inline]
     pub fn delayed(&self, new_time: &T) -> Capability<T> {
-        assert!(self.time.less_equal(new_time));
+        if !self.time.less_equal(new_time) {
+            panic!("Attempted to delay {:?} to {:?}, which is not `less_equal` the capability's time.", self, new_time);
+        }
         mint(new_time.clone(), self.internal.clone())
+    }
+
+    /// Downgrades the capability to one corresponding to `new_time`.
+    ///
+    /// This method panics if `self.time` is not less or equal to `new_time`.
+    #[inline]
+    pub fn downgrade(&mut self, new_time: &T) {
+        let new_cap = self.delayed(new_time);
+        *self = new_cap;
     }
 }
 
@@ -80,7 +98,6 @@ impl<T: Timestamp> Clone for Capability<T> {
 
 impl<T: Timestamp> Deref for Capability<T> {
     type Target = T;
-
     fn deref(&self) -> &T {
         &self.time
     }
@@ -89,5 +106,58 @@ impl<T: Timestamp> Deref for Capability<T> {
 impl<T: Timestamp> Debug for Capability<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Capability {{ time: {:?}, internal: ... }}", self.time)
+    }
+}
+
+impl<T: Timestamp> PartialEq for Capability<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.time() == other.time() && Rc::ptr_eq(&self.internal, &other.internal)
+    }
+}
+impl<T: Timestamp> Eq for Capability<T> { }
+
+impl<T: Timestamp> PartialOrder for Capability<T> {
+    fn less_equal(&self, other: &Self) -> bool {
+        self.time().less_equal(other.time()) && Rc::ptr_eq(&self.internal, &other.internal)
+    }
+}
+
+/// A set of capabilities, for possibly incomparable times.
+pub struct CapabilitySet<T: Timestamp> {
+    elements: Vec<Capability<T>>,
+}
+
+impl<T: Timestamp> CapabilitySet<T> {
+
+    /// Allocates an empty capability set.
+    pub fn new() -> Self {
+        CapabilitySet { elements: Vec::new() }
+    }
+
+    /// Inserts `capability` into the set, discarding redundant capabilities.
+    pub fn insert(&mut self, capability: Capability<T>) {
+        if !self.elements.iter().any(|c| c.less_equal(&capability)) {
+            self.elements.retain(|c| !capability.less_equal(c));
+            self.elements.push(capability);
+        }
+    }
+
+    /// Creates a new capability to send data at `time`.
+    ///
+    /// This method panics if there does not exist a capability in `self.elements` less or equal to `time`.
+    pub fn delayed(&self, time: &T) -> Capability<T> {
+        self.elements.iter().find(|c| c.time().less_equal(time)).unwrap().delayed(time)
+    }
+
+    /// Downgrades the set of capabilities to correspond with the times in `frontier`.
+    ///
+    /// This method panics if any element of `frontier` is not greater or equal to some element of `self.elements`.
+    pub fn downgrade(&mut self, frontier: &[T]) {
+        let count = self.elements.len();
+        for time in frontier.iter() {
+            let capability = self.delayed(time);
+            self.elements.push(capability);
+        }
+        self.elements.drain(..count);
     }
 }

--- a/src/dataflow/operators/capture.rs
+++ b/src/dataflow/operators/capture.rs
@@ -497,7 +497,7 @@ impl<T:Timestamp, D: Data, P: EventPusher<T, D>> Operate<T> for CaptureOperator<
 
     fn pull_internal_progress(&mut self, consumed: &mut [CountMap<T>],  _: &mut [CountMap<T>], _: &mut [CountMap<T>]) -> bool {
         while let Some((time, data)) = self.input.next() {
-            self.events.push(Event::Messages(*time, data.deref_mut().clone()));
+            self.events.push(Event::Messages(time.clone(), data.deref_mut().clone()));
         }
         self.input.pull_progress(&mut consumed[0]);
         false

--- a/src/dataflow/operators/count.rs
+++ b/src/dataflow/operators/count.rs
@@ -60,7 +60,7 @@ where G::Timestamp: Hash {
         let mut accums = HashMap::new();
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {
             input.for_each(|time, data| {
-                logic(&mut accums.entry(time.time()).or_insert(default.clone()), data);
+                logic(&mut accums.entry(time.time().clone()).or_insert(default.clone()), data);
                 notificator.notify_at(time);
             });
 

--- a/src/dataflow/operators/delay.rs
+++ b/src/dataflow/operators/delay.rs
@@ -81,7 +81,7 @@ where G::Timestamp: Hash {
                 for datum in data.drain(..) {
                     let new_time = func(&datum, &time);
                     assert!(time.time().less_equal(&new_time));
-                    elements.entry(new_time)
+                    elements.entry(new_time.clone())
                             .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time)); Vec::new() })
                             .push(datum);
                 }
@@ -106,7 +106,7 @@ where G::Timestamp: Hash {
                 let spare = stash.pop().unwrap_or_else(Vec::new);
                 let data = ::std::mem::replace(data.deref_mut(), spare);
 
-                elements.entry(new_time)
+                elements.entry(new_time.clone())
                         .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time)); Vec::new() })
                         .push(data);
             });

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -79,7 +79,7 @@ impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, T, D>> EnterAt<G, T, D> for E
 where G::Timestamp: Hash, T: Hash {
     fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Child<'a, G, T>, initial: F) ->
         Stream<Child<'a, G, T>, D> {
-            self.enter(scope).delay(move |datum, time| Product::new(time.outer, initial(datum)))
+            self.enter(scope).delay(move |datum, time| Product::new(time.outer.clone(), initial(datum)))
     }
 }
 
@@ -146,7 +146,7 @@ impl<TOuter: Timestamp, TInner: Timestamp, TData: Data> Push<(TOuter, Content<TD
     fn push(&mut self, message: &mut Option<(TOuter, Content<TData>)>) {
         if let Some((ref time, ref mut data)) = *message {
             let content = ::std::mem::replace(data, Content::Typed(Vec::new()));
-            let mut message = Some((Product::new(*time, Default::default()), content));
+            let mut message = Some((Product::new(time.clone(), Default::default()), content));
             self.targets.push(&mut message);
             if let Some((_, content)) = message {
                 *data = content;
@@ -167,7 +167,7 @@ where TOuter: Timestamp, TInner: Timestamp, TData: Data {
     fn push(&mut self, message: &mut Option<(Product<TOuter, TInner>, Content<TData>)>) {
         if let Some((ref time, ref mut data)) = *message {
             let content = ::std::mem::replace(data, Content::Typed(Vec::new()));
-            let mut message = Some((time.outer, content));
+            let mut message = Some((time.outer.clone(), content));
             self.targets.push(&mut message);
             if let Some((_, content)) = message {
                 *data = content;

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -53,7 +53,7 @@ impl<'a, G: ScopeParent, T: Timestamp> LoopVariable<'a, G, T> for Child<'a, G, T
 
         let feedback_output = Counter::new(targets, produced.clone());
         let feedback_input =  Counter::new(Observer {
-            limit: limit, summary: summary, targets: feedback_output
+            limit: limit, summary: summary.clone(), targets: feedback_output
         }, consumed.clone());
 
         let index = self.add_operator(Operator {
@@ -143,7 +143,7 @@ impl<T:Timestamp> Operate<T> for Operator<T> {
     fn outputs(&self) -> usize { 1 }
 
     fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Vec<CountMap<T>>) {
-        (vec![vec![Antichain::from_elem(self.summary)]], vec![CountMap::new()])
+        (vec![vec![Antichain::from_elem(self.summary.clone())]], vec![CountMap::new()])
     }
 
     fn pull_internal_progress(&mut self, messages_consumed: &mut [CountMap<T>],

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -82,8 +82,13 @@ impl<TOuter: Timestamp, TInner: Timestamp, D: Data> Push<(Product<TOuter, TInner
     #[inline]
     fn push(&mut self, message: &mut Option<(Product<TOuter, TInner>, Content<D>)>) {
         let active = if let Some((ref mut time, _)) = *message {
-            time.inner = self.summary.results_in(&time.inner);
-            time.inner.less_equal(&self.limit)
+            if let Some(new_time) = self.summary.results_in(&time.inner) {
+                time.inner = new_time;
+                time.inner.less_equal(&self.limit)
+            }
+            else {
+                false
+            }
         }
         else { true };
 

--- a/src/dataflow/operators/handles.rs
+++ b/src/dataflow/operators/handles.rs
@@ -33,8 +33,8 @@ impl<'a, T: Timestamp, D> InputHandle<'a, T, D> {
     #[inline]
     pub fn next(&mut self) -> Option<(Capability<T>, &mut Content<D>)> {
         let internal = &mut self.internal;
-        self.pull_counter.next().map(|(&time, content)| {
-            (mint_capability(time, internal.clone()), content)
+        self.pull_counter.next().map(|(time, content)| {
+            (mint_capability(time.clone(), internal.clone()), content)
         })
     }
 
@@ -140,7 +140,7 @@ impl<'a, T: Timestamp, D, P: Push<(T, Content<D>)>> OutputHandle<'a, T, D, P> {
     ///     (0..10).to_stream(scope)
     ///            .unary_stream(Pipeline, "example", |input, output| {
     ///                input.for_each(|cap, data| {
-    ///                    let mut time = cap.time();
+    ///                    let mut time = cap.time().clone();
     ///                    time.inner += 1;
     ///                    output.session(&cap.delayed(&time)).give_content(data);
     ///                });

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -140,7 +140,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
 
     // flushes any data we are sitting on. may need to initialize self.now_at if no one has yet.
     fn flush(&mut self) {
-        Content::push_at(&mut self.buffer, self.now_at, &mut self.pusher);
+        Content::push_at(&mut self.buffer, self.now_at.clone(), &mut self.pusher);
     }
 
     // closes the current epoch, flushing if needed, shutting if needed, and updating the frontier.
@@ -165,7 +165,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// This method flushes single elements previously sent with `send`, to keep the insertion order.
     pub fn send_batch(&mut self, buffer: &mut Vec<D>) {
         self.flush();
-        Content::push_at(buffer, self.now_at, &mut self.pusher);        
+        Content::push_at(buffer, self.now_at.clone(), &mut self.pusher);        
     }
 
     /// Advances the current epoch to `next`.

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -66,4 +66,4 @@ pub use self::notificator::FrontierNotificator;
 
 // keep "mint" module-private
 mod capability;
-pub use self::capability::Capability;
+pub use self::capability::{Capability, CapabilitySet};

--- a/src/dataflow/operators/notificator.rs
+++ b/src/dataflow/operators/notificator.rs
@@ -1,4 +1,3 @@
-use order::PartialOrder;
 use progress::frontier::MutableAntichain;
 use progress::Timestamp;
 use progress::count_map::CountMap;

--- a/src/dataflow/operators/notificator.rs
+++ b/src/dataflow/operators/notificator.rs
@@ -63,7 +63,7 @@ impl<T: Timestamp> Notificator<T> {
     ///            .unary_notify(Pipeline, "example", Vec::new(), |input, output, notificator| {
     ///                input.for_each(|cap, data| {
     ///                    output.session(&cap).give_content(data);
-    ///                    let mut time = cap.time();
+    ///                    let mut time = cap.time().clone();
     ///                    time.inner += 1;
     ///                    notificator.notify_at(cap.delayed(&time));
     ///                });
@@ -181,6 +181,7 @@ fn drain_into_if_behaves_correctly() {
 fn notificator_delivers_notifications_in_topo_order() {
     use std::rc::Rc;
     use std::cell::RefCell;
+    use order::PartialOrder;
     use progress::nested::product::Product;
     use progress::timestamp::RootTimestamp;
     use dataflow::operators::capability::mint as mint_capability;
@@ -273,15 +274,15 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///             let mut stash = HashMap::new();
 ///             move |input1, input2, output| {
 ///                 while let Some((time, data)) = input1.next() {
-///                     stash.entry(time.time()).or_insert(Vec::new()).extend(data.drain(..));
+///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
 ///                     notificator.notify_at(time);
 ///                 }
 ///                 while let Some((time, data)) = input2.next() {
-///                     stash.entry(time.time()).or_insert(Vec::new()).extend(data.drain(..));
+///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
 ///                     notificator.notify_at(time);
 ///                 }
 ///                 for time in notificator.iter(&[input1.frontier(), input2.frontier()]) {
-///                     if let Some(mut vec) = stash.remove(&time.time()) {
+///                     if let Some(mut vec) = stash.remove(time.time()) {
 ///                         output.session(&time).give_iterator(vec.drain(..));
 ///                     }
 ///                 }
@@ -335,7 +336,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                move |input, output| {
     ///                    input.for_each(|cap, data| {
     ///                        output.session(&cap).give_content(data);
-    ///                        let mut time = cap.time();
+    ///                        let mut time = cap.time().clone();
     ///                        time.inner += 1;
     ///                        notificator.notify_at(cap.delayed(&time));
     ///                    });

--- a/src/dataflow/operators/operator.rs
+++ b/src/dataflow/operators/operator.rs
@@ -53,10 +53,10 @@ pub trait Operator<G: Scope, D1: Data> {
     ///                         output.session(&c).give(12);
     ///                     }
     ///                     while let Some((time, data)) = input.next() {
-    ///                         stash.entry(time.time()).or_insert(Vec::new());
+    ///                         stash.entry(time.time().clone()).or_insert(Vec::new());
     ///                     }
     ///                     for time in notificator.iter(&[input.frontier()]) {
-    ///                         if let Some(mut vec) = stash.remove(&time.time()) {
+    ///                         if let Some(mut vec) = stash.remove(time.time()) {
     ///                             output.session(&time).give_iterator(vec.drain(..));
     ///                         }
     ///                     }
@@ -124,15 +124,15 @@ pub trait Operator<G: Scope, D1: Data> {
     ///            let mut stash = HashMap::new();
     ///            move |input1, input2, output| {
     ///                while let Some((time, data)) = input1.next() {
-    ///                    stash.entry(time.time()).or_insert(Vec::new()).extend(data.drain(..));
+    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
     ///                    notificator.notify_at(time);
     ///                }
     ///                while let Some((time, data)) = input2.next() {
-    ///                    stash.entry(time.time()).or_insert(Vec::new()).extend(data.drain(..));
+    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
     ///                    notificator.notify_at(time);
     ///                }
     ///                for time in notificator.iter(&[input1.frontier(), input2.frontier()]) {
-    ///                    if let Some(mut vec) = stash.remove(&time.time()) {
+    ///                    if let Some(mut vec) = stash.remove(time.time()) {
     ///                        output.session(&time).give_iterator(vec.drain(..));
     ///                    }
     ///                }
@@ -280,7 +280,7 @@ fn binary_base<G: Scope, D1: Data, D2: Data, D3: Data, P1, P2>(
 ///             let mut done = false;
 ///             if let Some(cap) = cap.as_mut() {
 ///                 // get some data and send it.
-///                 let mut time = cap.time();
+///                 let mut time = cap.time().clone();
 ///                 output.session(&cap)
 ///                       .give(cap.time().inner);
 ///

--- a/src/dataflow/scopes/root.rs
+++ b/src/dataflow/scopes/root.rs
@@ -101,7 +101,7 @@ impl<A: Allocate> Root<A> {
         operator.set_external_summary(Vec::new(), &mut []);
 
         let wrapper = Wrapper {
-            index: dataflow_index,
+            _index: dataflow_index,
             operate: Some(Box::new(operator)),
             resources: Some(Box::new(resources)),
         };
@@ -147,7 +147,7 @@ impl<A: Allocate> Clone for Root<A> {
 }
 
 struct Wrapper {
-    index: usize,
+    _index: usize,
     operate: Option<Box<Operate<RootTimestamp>>>,
     resources: Option<Box<Any>>,
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -26,4 +26,4 @@ impl PartialOrder for i32 { #[inline(always)] fn less_equal(&self, other: &Self)
 impl PartialOrder for i64 { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
 impl PartialOrder for isize { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { *self <= *other } }
 
-impl PartialOrder for () { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }
+impl PartialOrder for () { #[inline(always)] fn less_equal(&self, _other: &Self) -> bool { true } }

--- a/src/progress/frontier.rs
+++ b/src/progress/frontier.rs
@@ -36,20 +36,26 @@ impl<T: PartialOrder> Antichain<T> {
     /// Clears the contents of the antichain.
     pub fn clear(&mut self) { self.elements.clear() }
 
-    /// Returns true if any item in the `MutableAntichain` is strictly less than the argument.
+    /// Returns true if any item in the antichain is strictly less than the argument.
     #[inline]
     pub fn less_than(&self, time: &T) -> bool {
         self.elements.iter().any(|x| x.less_than(time))
     }
 
-    /// Returns true if any item in the `MutableAntichain` is less than or equal to the argument.
+    /// Returns true if any item in the antichain is less than or equal to the argument.
     #[inline]
     pub fn less_equal(&self, time: &T) -> bool {
         self.elements.iter().any(|x| x.less_equal(time))
     }
+
+    /// Returns true if every element of `other` is greater or equal to some element of `self`.
+    #[inline]
+    pub fn dominates(&self, other: &Antichain<T>) -> bool {
+        other.elements().iter().all(|t2| self.elements().iter().any(|t1| t1.less_equal(t2)))
+    }
     
     /// Reveals the elements in the antichain.
-    pub fn elements(&self) -> &[T] { &self.elements[..] }
+    #[inline] pub fn elements(&self) -> &[T] { &self.elements[..] }
 }
 
 /// An antichain based on a multiset whose elements frequencies can be updated.

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -144,7 +144,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         // that they are `Product<TOuter, TInner>`, and we just want `TOuter`.
         let mut initial_capabilities = vec![CountMap::new(); self.outputs()];
         for (o_port, capabilities) in self.pointstamps.pushed[0].iter().enumerate() {
-            for &(time, val) in capabilities.iter() {
+            for &(ref time, val) in capabilities.iter() {
                 // make a note to self and inform scope of our capability.
                 self.output_capabilities[o_port].update(&time.outer, val);
                 initial_capabilities[o_port].update(&time.outer, val);
@@ -158,10 +158,10 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         for input in 0..self.inputs() {
             for &(target, ref antichain) in &self.children[0].source_target_summaries[input] {
                 if target.index == 0 {
-                    for &summary in antichain.elements().iter() {
+                    for summary in antichain.elements().iter() {
                         internal_summary[input][target.port].insert(match summary {
-                            Local(_)    => Default::default(),
-                            Outer(y, _) => y,
+                            &Local(_)    => Default::default(),
+                            &Outer(ref y, _) => y.clone(),
                         });
                     };
                 }
@@ -185,11 +185,11 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         // external capabilities on the subgraph's inputs.
         for output in 0..self.outputs {
             for input in 0..self.inputs {
-                for &summary in summaries[output][input].elements() {
+                for summary in summaries[output][input].elements() {
                     try_to_add_summary(
                         &mut self.children[0].target_source_summaries[output],
                         Source { index: 0, port: input },
-                        Outer(summary, Default::default())
+                        Outer(summary.clone(), Default::default())
                     );
                 }
             }
@@ -253,7 +253,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
             for output in 0..child.outputs {
                 for &(source, ref antichain) in &child.source_target_summaries[output] {
                     if source.index == child.index {
-                        summary[output][source.port] = antichain.clone();
+                        summary[output][source.port] = (*antichain).clone();
                     }
                 }
             }
@@ -314,9 +314,9 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         for input in 0..self.inputs {
             let mut borrowed = self.input_messages[input].borrow_mut();
             while let Some((time, delta)) = borrowed.pop() {
-                self.local_pointstamp_internal.update(&(0, input, time), delta);
+                self.local_pointstamp_internal.update(&(0, input, time.clone()), delta);
                 for target in &self.children[0].edges[input] {
-                    self.local_pointstamp_messages.update(&(target.index, target.port, time), delta);
+                    self.local_pointstamp_messages.update(&(target.index, target.port, time.clone()), delta);
                 }
             }
         }
@@ -539,8 +539,8 @@ impl<TOuter: Timestamp, TInner: Timestamp> Subgraph<TOuter, TInner> {
                     if let Some(summary) = summary.followed_by(new_summary) {
                         let edges = self.children[new_source.index].edges[new_source.port].clone();
                         for &new_target in &edges {
-                            if try_to_add_summary(&mut self.children[source.index].source_target_summaries[source.port], new_target, summary) {
-                                additions.push_back((source, new_target, summary));
+                            if try_to_add_summary(&mut self.children[source.index].source_target_summaries[source.port], new_target, summary.clone()) {
+                                additions.push_back((source, new_target, summary.clone()));
                             }
                         }
                     }
@@ -670,7 +670,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Subgraph<TOuter, TInner> {
     }
 }
 
-fn try_to_add_summary<T: Eq, S: PartialOrder+Eq+Copy+Debug>(vector: &mut Vec<(T, Antichain<S>)>, target: T, summary: S) -> bool {
+fn try_to_add_summary<T: Eq, S: PartialOrder+Eq+Debug>(vector: &mut Vec<(T, Antichain<S>)>, target: T, summary: S) -> bool {
     for &mut (ref t, ref mut antichain) in vector.iter_mut() {
         if target.eq(t) { return antichain.insert(summary); }
     }
@@ -781,8 +781,8 @@ impl<T: Timestamp> PerOperatorState<T> {
         let mut new_summary = vec![Vec::new(); inputs];
         for input in 0..inputs {
             for output in 0..outputs {
-                for &summary in summary[input][output].elements() {
-                    try_to_add_summary(&mut new_summary[input], Source { index: index, port: output }, summary);
+                for summary in summary[input][output].elements() {
+                    try_to_add_summary(&mut new_summary[input], Source { index: index, port: output }, summary.clone());
                 }
             }
         }
@@ -931,7 +931,7 @@ impl<T: Timestamp> PerOperatorState<T> {
         for output in 0..self.outputs {
             while let Some((time, delta)) = self.produced_buffer[output].pop() {
                 for target in &self.edges[output] {
-                    pointstamp_messages.update(&(target.index, target.port, time), delta);
+                    pointstamp_messages.update(&(target.index, target.port, time.clone()), delta);
                 }
             }
 

--- a/src/progress/nested/summary.rs
+++ b/src/progress/nested/summary.rs
@@ -38,12 +38,12 @@ impl<S, T: Default> Default for Summary<S, T> {
 // on tuples is lexicographic, so this would put a small outer summary and large inner installment ahead
 // of a larger outer summary with small inner installment. I don't think that is correct (they should be
 // unordered.
-impl<S: PartialOrder+Copy, T: PartialOrder+Copy> PartialOrder for Summary<S, T> {
+impl<S: PartialOrder, T: PartialOrder> PartialOrder for Summary<S, T> {
     #[inline(always)]
     fn less_equal(&self, other: &Self) -> bool {
-        match (*self, *other) {
-            (Local(t1),    Local(t2))    => t1.less_equal(&t2),
-            (Outer(s1,t1), Outer(s2,t2)) => s1.less_equal(&s2) && t1.less_equal(&t2),
+        match (self, other) {
+            (&Local(ref t1), &Local(ref t2)) => t1.less_equal(&t2),
+            (&Outer(ref s1, ref t1), &Outer(ref s2, ref t2)) => s1.less_equal(&s2) && t1.less_equal(&t2),
             _  => false
         }
     }
@@ -74,17 +74,17 @@ where TOuter: Timestamp,
     #[inline]
     fn results_in(&self, product: &Product<TOuter, TInner>) -> Option<Product<TOuter, TInner>> {
         match *self {
-            Local(ref iters)              => iters.results_in(&product.inner).map(|x| Product::new(product.outer, x)),
+            Local(ref iters)              => iters.results_in(&product.inner).map(|x| Product::new(product.outer.clone(), x)),
             Outer(ref summary, ref iters) => summary.results_in(&product.outer).map(|x| Product::new(x, iters.results_in(&Default::default()).unwrap())),
         }
     }
     #[inline]
     fn followed_by(&self, other: &Summary<SOuter, SInner>) -> Option<Summary<SOuter, SInner>> {
-        match (*self, *other) {
-            (Local(inner1), Local(inner2))             => inner1.followed_by(&inner2).map(|x| Local(x)),
-            (Local(_), Outer(_, _))                    => Some(*other),
-            (Outer(outer1, inner1), Local(inner2))     => inner1.followed_by(&inner2).map(|x| Outer(outer1, x)),
-            (Outer(outer1, _), Outer(outer2, inner2))  => outer1.followed_by(&outer2).map(|x| Outer(x, inner2)),
+        match (self, other) {
+            (&Local(ref inner1), &Local(ref inner2))                 => inner1.followed_by(inner2).map(|x| Local(x)),
+            (&Local(_), &Outer(_, _))                                => Some(other.clone()),
+            (&Outer(ref outer1, ref inner1), &Local(ref inner2))     => inner1.followed_by(inner2).map(|x| Outer(outer1.clone(), x)),
+            (&Outer(ref outer1, _), &Outer(ref outer2, ref inner2))  => outer1.followed_by(outer2).map(|x| Outer(x, inner2.clone())),
         }
     }
 }

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -25,9 +25,46 @@ pub trait Timestamp: Copy+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation {
 /// A summary of how a timestamp advances along a timely dataflow path.
 pub trait PathSummary<T> : 'static+Copy+Eq+PartialOrder+Debug+Default {
     /// Advances a timestamp according to the timestamp actions on the path.
-    fn results_in(&self, src: &T) -> T;
+    ///
+    /// The path may advance the timestamp sufficiently that it is no longer valid, for example if
+    /// incrementing fields would result in integer overflow. In this case, `results_in` should 
+    /// return `None`.
+    ///
+    /// The `feedback` operator, apparently the only point where timestamps are actually incremented
+    /// in computation, uses this method and will drop messages with timestamps that when advanced
+    /// result in `None`. Ideally, all other timestamp manipulation should behave similarly.
+    ///
+    /// #Examples
+    /// ```
+    /// use timely::progress::timestamp::PathSummary;
+    ///
+    /// let timestamp = 3;
+    ///
+    /// let summary1 = 5;
+    /// let summary2 = usize::max_value() - 2;
+    /// 
+    /// assert_eq!(summary1.results_in(&timestamp), Some(8));
+    /// assert_eq!(summary2.results_in(&timestamp), None);
+    /// ```
+    fn results_in(&self, src: &T) -> Option<T>;
     /// Composes this path summary with another path summary.
-    fn followed_by(&self, other: &Self) -> Self;
+    ///
+    /// It is possible that the two composed paths result in an invalid summary, for example when 
+    /// integer additions overflow. If it is correct that all timestamps moved along these paths 
+    /// would also result in overflow and be discarded, `followed_by` can return `None. It is very
+    /// important that this not be used casually, as this does not prevent the actual movement of 
+    /// data. 
+    ///
+    /// #Examples
+    /// ```
+    /// use timely::progress::timestamp::PathSummary;
+    ///
+    /// let summary1 = 5;
+    /// let summary2 = usize::max_value() - 3;
+    /// 
+    /// assert_eq!(summary1.followed_by(&summary2), None);
+    /// ```    
+    fn followed_by(&self, other: &Self) -> Option<Self>;
 }
 
 /// An empty timestamp used by the root scope.
@@ -57,9 +94,9 @@ impl RootTimestamp {
 pub struct RootSummary;
 impl PathSummary<RootTimestamp> for RootSummary {
     #[inline]
-    fn results_in(&self, _: &RootTimestamp) -> RootTimestamp { RootTimestamp }
+    fn results_in(&self, _: &RootTimestamp) -> Option<RootTimestamp> { Some(RootTimestamp) }
     #[inline]
-    fn followed_by(&self, _: &RootSummary) -> RootSummary { RootSummary }
+    fn followed_by(&self, _: &RootSummary) -> Option<RootSummary> { Some(RootSummary) }
 }
 
 impl PartialOrder for RootSummary { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }
@@ -67,38 +104,38 @@ impl PartialOrder for RootSummary { #[inline(always)] fn less_equal(&self, other
 
 impl Timestamp for () { type Summary = (); }
 impl PathSummary<()> for () {
-    fn results_in(&self, _src: &()) -> () { () }
-    fn followed_by(&self, _other: &()) -> () { () }
+    fn results_in(&self, _src: &()) -> Option<()> { Some(()) }
+    fn followed_by(&self, _other: &()) -> Option<()> { Some(()) }
 }
 
 impl Timestamp for usize { type Summary = usize; }
 impl PathSummary<usize> for usize {
     #[inline]
-    fn results_in(&self, src: &usize) -> usize { *self + *src }
+    fn results_in(&self, src: &usize) -> Option<usize> { self.checked_add(*src) }
     #[inline]
-    fn followed_by(&self, other: &usize) -> usize { *self + *other }
+    fn followed_by(&self, other: &usize) -> Option<usize> { self.checked_add(*other) }
 }
 
 impl Timestamp for u64 { type Summary = u64; }
 impl PathSummary<u64> for u64 {
     #[inline]
-    fn results_in(&self, src: &u64) -> u64 { *self + *src }
+    fn results_in(&self, src: &u64) -> Option<u64> { self.checked_add(*src) }
     #[inline]
-    fn followed_by(&self, other: &u64) -> u64 { *self + *other }
+    fn followed_by(&self, other: &u64) -> Option<u64> { self.checked_add(*other) }
 }
 
 impl Timestamp for u32 { type Summary = u32; }
 impl PathSummary<u32> for u32 {
     #[inline]
-    fn results_in(&self, src: &u32) -> u32 { *self + *src }
+    fn results_in(&self, src: &u32) -> Option<u32> { self.checked_add(*src) }
     #[inline]
-    fn followed_by(&self, other: &u32) -> u32 { *self + *other }
+    fn followed_by(&self, other: &u32) -> Option<u32> { self.checked_add(*other) }
 }
 
 impl Timestamp for i32 { type Summary = i32; }
 impl PathSummary<i32> for i32 {
     #[inline]
-    fn results_in(&self, src: &i32) -> i32 { *self + *src }
+    fn results_in(&self, src: &i32) -> Option<i32> { self.checked_add(*src) }
     #[inline]
-    fn followed_by(&self, other: &i32) -> i32 { *self + *other }
+    fn followed_by(&self, other: &i32) -> Option<i32> { self.checked_add(*other) }
 }

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -78,7 +78,7 @@ impl Debug for RootTimestamp {
     }
 }
 
-impl PartialOrder for RootTimestamp { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }
+impl PartialOrder for RootTimestamp { #[inline(always)] fn less_equal(&self, _other: &Self) -> bool { true } }
 
 impl Abomonation for RootTimestamp { }
 impl RootTimestamp {
@@ -99,7 +99,7 @@ impl PathSummary<RootTimestamp> for RootSummary {
     fn followed_by(&self, _: &RootSummary) -> Option<RootSummary> { Some(RootSummary) }
 }
 
-impl PartialOrder for RootSummary { #[inline(always)] fn less_equal(&self, other: &Self) -> bool { true } }
+impl PartialOrder for RootSummary { #[inline(always)] fn less_equal(&self, _other: &Self) -> bool { true } }
 
 
 impl Timestamp for () { type Summary = (); }

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -13,7 +13,7 @@ use abomonation::Abomonation;
 
 // TODO : Change Copy requirement to Clone;
 /// A composite trait for types that serve as timestamps in timely dataflow.
-pub trait Timestamp: Copy+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation {
+pub trait Timestamp: Clone+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation {
     /// A type summarizing action on a timestamp along a dataflow path.
     type Summary : PathSummary<Self> + 'static;
 }
@@ -23,7 +23,7 @@ pub trait Timestamp: Copy+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation {
 // TODO : This can be important when a summary would "overflow", as we want neither to overflow,
 // TODO : nor wrap around, nor saturate.
 /// A summary of how a timestamp advances along a timely dataflow path.
-pub trait PathSummary<T> : 'static+Copy+Eq+PartialOrder+Debug+Default {
+pub trait PathSummary<T> : Clone+'static+Eq+PartialOrder+Debug+Default {
     /// Advances a timestamp according to the timestamp actions on the path.
     ///
     /// The path may advance the timestamp sufficiently that it is no longer valid, for example if


### PR DESCRIPTION
This PR introduces a few important changes, and a few breaking changes that are meant to be improvements.

1. Path summaries now return optional timestamps, and can so indicate that a timestamp does not traverse the path. This is important in the case of overflow, where the correct options are none of (i) wrap, (ii) saturate, (iii) panic. Instead, such paths just stop. 

2. Path summaries can also return option summaries in `followed_by`. This is a bit more dangerous, in that this does not prevent the movement of data, it just promises that any timestamps moving along the concatenation of these two paths will be discarded. This is also important for overflow (though I expect there were fewer overflowing paths, you can build them), but conservative implementations could just do checked arithmetic and panic on overflow, if this is more re-assuring.

3. Antichain got a `dominates` method, which is roughly `less_equal` on the partial order of antichains: it returns true iff every element of the second argument is greater or equal to some element in the first argument. It is not yet appropriate to implement `PartialOrder` because equality testing is a bit borked, because antichains do not maintain a canonical representation (e.g. require `T: Ord` and sort), and it would be bad to have a quadratic `eq` implementation.

4. `Timestamp` and `PathSummary` now require `Clone` instead of `Copy`. This means one could use `Vec<_>` as a timestamp, for something like nested data parallelism. It also means that a few timestamp-related methods have their types changed. The most important one is ..

5. Capabilities got tweaked a bit. Importantly, the `time()` method now returns a `&T` rather than copying to a `T`. This means that uses of `.time()` may need a `.clone()` after them if the owned value was then used as such (common examples: used as a hashmap key with `entry()` and mutating a field in the resulting time, both of which need a clone).

6. Capabilities got a `downgrade` method which is equivalent to setting *self to self.delayed(). This method exists to parallel ..

7. A new `CapabilitySet<T>` type, representing a minimal antichain of capabilities. The set can be inserted into, produce new capabilities with `delayed`, and downgrade itself to a dominated frontier.