### PR TITLE
Make Timestamp depend on Hash

### DIFF
--- a/src/dataflow/operators/aggregation/aggregate.rs
+++ b/src/dataflow/operators/aggregation/aggregate.rs
@@ -66,7 +66,7 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
 		F: Fn(&K, V, &mut D)+'static, 
 		G: Fn(K, D)->R+'static,
 		H: Fn(&K)->u64+'static,
-	>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp : Hash+Eq;
+	>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp: Eq;
 } 
 
 impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, (K, V)> {
@@ -77,7 +77,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for 
 			F: Fn(&K, V, &mut D)+'static, 
 			G: Fn(K, D)->R+'static,
 			H: Fn(&K)->u64+'static,
-		>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp : Hash+Eq {
+		>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp: Eq {
 
 		let mut aggregates = HashMap::new(); 
 

--- a/src/dataflow/operators/count.rs
+++ b/src/dataflow/operators/count.rs
@@ -1,6 +1,5 @@
 //! Counts the number of records at each time.
 use std::collections::HashMap;
-use std::hash::Hash;
 
 use Data;
 use dataflow::channels::pact::Pipeline;
@@ -53,8 +52,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     }
 }
 
-impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, D>
-where G::Timestamp: Hash {
+impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, D> {
     fn accumulate<A: Data, F: Fn(&mut A, &mut Content<D>)+'static>(&self, default: A, logic: F) -> Stream<G, A> {
 
         let mut accums = HashMap::new();

--- a/src/dataflow/operators/delay.rs
+++ b/src/dataflow/operators/delay.rs
@@ -1,6 +1,5 @@
 //! Operators acting on timestamps to logically delay records
 
-use std::hash::Hash;
 use std::collections::HashMap;
 use std::ops::DerefMut;
 
@@ -72,8 +71,7 @@ pub trait Delay<G: Scope, D: Data> {
     fn delay_batch<F: Fn(&G::Timestamp)->G::Timestamp+'static>(&self, F) -> Self;
 }
 
-impl<G: Scope, D: Data> Delay<G, D> for Stream<G, D>
-where G::Timestamp: Hash {
+impl<G: Scope, D: Data> Delay<G, D> for Stream<G, D> {
     fn delay<F: Fn(&D, &G::Timestamp)->G::Timestamp+'static>(&self, func: F) -> Stream<G, D> {
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -19,7 +19,6 @@
 //! });
 //! ```
 
-use std::hash::Hash;
 use std::default::Default;
 
 use std::rc::Rc;
@@ -57,7 +56,7 @@ pub trait Enter<G: Scope, T: Timestamp, D: Data> {
 }
 
 /// Extension trait to move a `Stream` into a child of its current `Scope` setting the timestamp for each element.
-pub trait EnterAt<G: Scope, T: Timestamp, D: Data>  where  G::Timestamp: Hash, T: Hash {
+pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {
     /// Moves the `Stream` argument into a child of its current `Scope` setting the timestamp for each element by `initial`.
     ///
     /// # Examples
@@ -75,8 +74,7 @@ pub trait EnterAt<G: Scope, T: Timestamp, D: Data>  where  G::Timestamp: Hash, T
     fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Child<'a, G, T>, initial: F) -> Stream<Child<'a, G, T>, D> ;
 }
 
-impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, T, D>> EnterAt<G, T, D> for E
-where G::Timestamp: Hash, T: Hash {
+impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, T, D>> EnterAt<G, T, D> for E {
     fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Child<'a, G, T>, initial: F) ->
         Stream<Child<'a, G, T>, D> {
             self.enter(scope).delay(move |datum, time| Product::new(time.outer.clone(), initial(datum)))

--- a/src/dataflow/operators/queue.rs
+++ b/src/dataflow/operators/queue.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::hash::Hash;
 
 use Data;
 use dataflow::channels::pact::Pipeline;
@@ -10,8 +9,7 @@ pub trait Queue {
     fn queue(&self) -> Self;
 }
 
-impl<G: Scope, D: Data> Queue for Stream<G, D>
-where G::Timestamp: Hash {
+impl<G: Scope, D: Data> Queue for Stream<G, D> {
     fn queue(&self) -> Stream<G, D> {
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Queue", vec![], move |input, output, notificator| {

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -5,6 +5,7 @@ use std::any::Any;
 use std::default::Default;
 use std::fmt::Formatter;
 use std::fmt::Error;
+use std::hash::Hash;
 
 use order::PartialOrder;
 use progress::nested::product::Product;
@@ -13,7 +14,7 @@ use abomonation::Abomonation;
 
 // TODO : Change Copy requirement to Clone;
 /// A composite trait for types that serve as timestamps in timely dataflow.
-pub trait Timestamp: Clone+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation {
+pub trait Timestamp: Clone+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation+Hash {
     /// A type summarizing action on a timestamp along a dataflow path.
     type Summary : PathSummary<Self> + 'static;
 }


### PR DESCRIPTION
This is mainly an ergonomics benefit. Since the timestamp in a scope is
often required to be `Hash`, generic code needs to specify that
explicitly. With this change it is implied by the `Timestamp` bound.

Since all existing implementations are `Hash` and the general intention
of a timestamp seems to be something that behaves mostly like an
integer, requiring `Hash` is probably not too much to ask. (Still it's
technically a breaking change.)