### PR TITLE
input_from introduced

### DIFF
--- a/examples/unionfind.rs
+++ b/examples/unionfind.rs
@@ -23,17 +23,16 @@ fn main() {
         let index = worker.index();
         let peers = worker.peers();
 
-        let (mut input, probe) = worker.dataflow(move |scope| {
+        let mut input = InputHandle::new();
+        let mut probe = ProbeHandle::new();
 
-            let (handle, stream) = scope.new_input();
-
-            let probe = stream//.exchange(move |x: &(usize, usize)| (x.0 % (peers - 1)) as u64 + 1)
-                              .union_find()
-                              .exchange(|_| 0)
-                              .union_find()
-                              .probe();
-
-            (handle, probe)
+        worker.dataflow(|scope| {
+            scope.input_from(&mut input)
+                //  .exchange(move |x: &(usize, usize)| (x.0 % (peers - 1)) as u64 + 1)
+                 .union_find()
+                 .exchange(|_| 0)
+                 .union_find()
+                 .probe_with(&mut probe);
         });
 
         let seed: &[_] = &[1, 2, 3, index];

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -16,6 +16,9 @@
 pub use self::stream::Stream;
 pub use self::scopes::{Scope, ScopeParent};
 
+pub use self::operators::input::Handle as InputHandle;
+pub use self::operators::probe::Handle as ProbeHandle;
+
 pub mod operators;
 pub mod channels;
 pub mod scopes;

--- a/src/dataflow/operators/binary.rs
+++ b/src/dataflow/operators/binary.rs
@@ -17,7 +17,7 @@ use dataflow::channels::pullers::counter::Counter as PullCounter;
 use dataflow::channels::pact::ParallelizationContract;
 use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 
-use dataflow::operators::{InputHandle, OutputHandle};
+use dataflow::operators::handles::{InputHandle, OutputHandle};
 use dataflow::operators::handles::{new_input_handle, new_output_handle};
 use dataflow::operators::capability::mint as mint_capability;
 

--- a/src/dataflow/operators/exchange.rs
+++ b/src/dataflow/operators/exchange.rs
@@ -13,7 +13,7 @@ pub trait Exchange<T, D: ExchangeData> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, ExchangeExtension, Inspect};
+    /// use timely::dataflow::operators::{ToStream, Exchange, Inspect};
     ///
     /// timely::example(|scope| {
     ///     (0..10).to_stream(scope)
@@ -28,7 +28,7 @@ pub trait Exchange<T, D: ExchangeData> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, ExchangeExtension, Inspect};
+    /// use timely::dataflow::operators::{ToStream, Exchange, Inspect};
     ///
     /// timely::example(|scope| {
     ///     (0..10).to_stream(scope)

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -62,23 +62,66 @@ pub trait Input<'a, A: Allocate, T: Timestamp+Ord> {
     /// });
     /// ```
     fn new_input<D: Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>);
+
+    /// Create a new stream from a supplied interactive handle.
+    ///
+    /// This method creates a new timely stream whose data are supplied interactively through the `handle`
+    /// argument. Each handle may be used multiple times (or not at all), and will clone data as appropriate 
+    /// if it as attached to more than one stream.
+    ///
+    /// #Examples
+    /// ```
+    /// use timely::*;
+    /// use timely::dataflow::operators::{Input, Inspect};
+    /// use timely::dataflow::operators::input::Handle;
+    ///
+    /// // construct and execute a timely dataflow
+    /// timely::execute(Configuration::Thread, |worker| {
+    ///
+    ///     // add an input and base computation off of it
+    ///     let mut input = Handle::new();
+    ///     worker.dataflow(|scope| {
+    ///         scope.input_from(&mut input)
+    ///              .inspect(|x| println!("hello {:?}", x));
+    ///     });
+    ///
+    ///     // introduce input, advance computation
+    ///     for round in 0..10 {
+    ///         input.send(round);
+    ///         input.advance_to(round + 1);
+    ///         worker.step();
+    ///     }
+    /// });
+    /// ```
+    fn input_from<D: Data>(&mut self, handle: &mut Handle<T, D>) -> Stream<Child<'a, Root<A>, T>, D>;
 }
 
 impl<'a, A: Allocate, T: Timestamp+Ord> Input<'a, A, T> for Child<'a, Root<A>, T> {
     fn new_input<D: Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Root<A>, T>, D>) {
+        let mut handle = Handle::new();
+        let stream = self.input_from(&mut handle);
+        (handle, stream)
+    }
+
+    fn input_from<D: Data>(&mut self, handle: &mut Handle<T, D>) -> Stream<Child<'a, Root<A>, T>, D> {
 
         let (output, registrar) = Tee::<Product<RootTimestamp, T>, D>::new();
         let produced = Rc::new(RefCell::new(CountMap::new()));
-        let helper = Handle::new(Counter::new(output, produced.clone()));
+        let counter = Counter::new(output, produced.clone());
+
+        let progress = Rc::new(RefCell::new(CountMap::new()));
+
+        handle.register(counter, progress.clone());
+
         let copies = self.peers();
 
         let index = self.add_operator(Operator {
-            progress: helper.progress.clone(),
+            progress: progress.clone(),
             messages: produced.clone(),
             copies:   copies,
         });
 
-        (helper, Stream::new(Source { index: index, port: 0 }, registrar, self.clone()))
+        Stream::new(Source { index: index, port: 0 }, registrar, self.clone())
     }
 }
 
@@ -115,47 +158,73 @@ impl<T:Timestamp+Ord> Operate<Product<RootTimestamp, T>> for Operator<T> {
 
 /// A handle to an input `Stream`, used to introduce data to a timely dataflow computation.
 pub struct Handle<T: Timestamp, D: Data> {
-    // frontier: Rc<RefCell<MutableAntichain<Product<RootTimestamp, T>>>>,   // times available for sending
-    progress: Rc<RefCell<CountMap<Product<RootTimestamp, T>>>>,           // times closed since last asked
-    pusher: Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>,
-    buffer: Vec<D>,
+    progress: Vec<Rc<RefCell<CountMap<Product<RootTimestamp, T>>>>>,
+    pushers: Vec<Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>>,
+    buffer1: Vec<D>,
+    buffer2: Vec<D>,
     now_at: Product<RootTimestamp, T>,
 }
 
-// an input helper's state is either uninitialized, with now_at == None, or at some specific time.
-// if now_at == None it has a hold on Default::default(), else it has a hold on the specific time.
-// if now_at == None the pusher has not been opened, else it is open with the specific time.
-
-
 impl<T:Timestamp, D: Data> Handle<T, D> {
-    fn new(pusher: Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>) -> Handle<T, D> {
+
+    /// Allocates a new input handle, from which one can create timely streams.
+    pub fn new() -> Self {
         Handle {
-            // frontier: Rc::new(RefCell::new(MutableAntichain::new_bottom(Default::default()))),
-            progress: Rc::new(RefCell::new(CountMap::new())),
-            pusher: pusher,
-            buffer: Vec::with_capacity(Content::<D>::default_length()),
+            progress: Vec::new(),
+            pushers: Vec::new(),
+            buffer1: Vec::with_capacity(Content::<D>::default_length()),
+            buffer2: Vec::with_capacity(Content::<D>::default_length()),
             now_at: Default::default(),
         }
     }
 
-    // flushes any data we are sitting on. may need to initialize self.now_at if no one has yet.
+    fn register(
+        &mut self,
+        pusher: Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>,
+        progress: Rc<RefCell<CountMap<Product<RootTimestamp, T>>>>
+    ) {
+        // we need to produce an appropriate update to the capabilities for `progress`, in case a
+        // user has decided to drive the handle around a bit before registering it.
+        progress.borrow_mut().update(&Default::default(), -1);
+        progress.borrow_mut().update(&self.now_at, 1);
+
+        self.progress.push(progress);
+        self.pushers.push(pusher);
+    }
+
+    // flushes our buffer at each of the destinations. there can be more than one; clone if needed.
     fn flush(&mut self) {
-        Content::push_at(&mut self.buffer, self.now_at.clone(), &mut self.pusher);
+        for index in 0 .. self.pushers.len() {
+            if index < self.pushers.len() - 1 {
+                self.buffer2.extend_from_slice(&self.buffer1[..]);
+                Content::push_at(&mut self.buffer2, self.now_at.clone(), &mut self.pushers[index]);
+                assert!(self.buffer2.is_empty());
+            }
+            else {
+                Content::push_at(&mut self.buffer1, self.now_at.clone(), &mut self.pushers[index]);
+                assert!(self.buffer1.is_empty());
+            }
+        }
+        self.buffer1.clear();
     }
 
     // closes the current epoch, flushing if needed, shutting if needed, and updating the frontier.
     fn close_epoch(&mut self) {
-        if !self.buffer.is_empty() { self.flush(); }
-        self.pusher.done();
-        self.progress.borrow_mut().update(&self.now_at, -1);
+        if !self.buffer1.is_empty() { self.flush(); }
+        for pusher in self.pushers.iter_mut() {
+            pusher.done();
+        }
+        for progress in self.progress.iter() {
+            progress.borrow_mut().update(&self.now_at, -1);
+        }
     }
 
     #[inline(always)]
     /// Sends one record into the corresponding timely dataflow `Stream`, at the current epoch.
     pub fn send(&mut self, data: D) {
         // assert!(self.buffer.capacity() == Content::<D>::default_length());
-        self.buffer.push(data);
-        if self.buffer.len() == self.buffer.capacity() {
+        self.buffer1.push(data);
+        if self.buffer1.len() == self.buffer1.capacity() {
             self.flush();
         }
     }
@@ -164,8 +233,23 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     ///
     /// This method flushes single elements previously sent with `send`, to keep the insertion order.
     pub fn send_batch(&mut self, buffer: &mut Vec<D>) {
-        if !self.buffer.is_empty() { self.flush(); }
-        Content::push_at(buffer, self.now_at.clone(), &mut self.pusher);        
+
+        // flush buffered elements to ensure local fifo.
+        if !self.buffer1.is_empty() { self.flush(); }
+
+        // push buffer (or clone of buffer) at each destination.
+        for index in 0 .. self.pushers.len() {
+            if index < self.pushers.len() - 1 {
+                self.buffer2.extend_from_slice(&buffer[..]);
+                Content::push_at(&mut self.buffer2, self.now_at.clone(), &mut self.pushers[index]);
+                assert!(self.buffer2.is_empty());
+            }
+            else {
+                Content::push_at(buffer, self.now_at.clone(), &mut self.pushers[index]);
+                assert!(buffer.is_empty());
+            }
+        }
+        buffer.clear();
     }
 
     /// Advances the current epoch to `next`.
@@ -176,7 +260,9 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
         assert!(self.now_at.inner.less_than(&next));
         self.close_epoch();
         self.now_at = RootTimestamp::new(next);
-        self.progress.borrow_mut().update(&self.now_at, 1);
+        for progress in self.progress.iter() {
+            progress.borrow_mut().update(&self.now_at, 1);
+        }
     }
 
     /// Closes the input.

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -260,7 +260,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// This method allows timely dataflow to issue progress notifications as it can now determine
     /// that this input can no longer produce data at earlier timestamps.
     pub fn advance_to(&mut self, next: T) {
-        assert!(self.now_at.inner.less_than(&next));
+        assert!(self.now_at.inner.less_equal(&next));
         self.close_epoch();
         self.now_at = RootTimestamp::new(next);
         for progress in self.progress.iter() {

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -183,6 +183,9 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
         pusher: Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>,
         progress: Rc<RefCell<CountMap<Product<RootTimestamp, T>>>>
     ) {
+        // flush current contents, so new registrant does not see existing data.
+        if !self.buffer1.is_empty() { self.flush(); }
+
         // we need to produce an appropriate update to the capabilities for `progress`, in case a
         // user has decided to drive the handle around a bit before registering it.
         progress.borrow_mut().update(&Default::default(), -1);

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -21,7 +21,7 @@ pub use self::inspect::Inspect;
 pub use self::filter::Filter;
 pub use self::binary::Binary;
 pub use self::delay::Delay;
-pub use self::exchange::Exchange as ExchangeExtension;
+pub use self::exchange::Exchange;
 pub use self::broadcast::Broadcast;
 pub use self::probe::Probe;
 pub use self::to_stream::ToStream;
@@ -58,7 +58,7 @@ pub mod count;
 
 // keep the handle constructors private
 mod handles;
-pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
+// pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
 
 mod notificator;
 pub use self::notificator::Notificator;

--- a/src/dataflow/operators/operator.rs
+++ b/src/dataflow/operators/operator.rs
@@ -19,7 +19,7 @@ use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use dataflow::channels::pact::ParallelizationContract;
 use dataflow::channels::pullers::Counter as PullCounter;
 
-use dataflow::operators::{InputHandle, FrontieredInputHandle, OutputHandle};
+use dataflow::operators::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
 use dataflow::operators::handles::{new_input_handle, new_frontier_input_handle, new_output_handle};
 use dataflow::operators::capability::Capability;
 use dataflow::operators::capability::mint as mint_capability;

--- a/src/dataflow/operators/unary.rs
+++ b/src/dataflow/operators/unary.rs
@@ -15,7 +15,7 @@ use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use dataflow::channels::pact::ParallelizationContract;
 use dataflow::channels::pullers::Counter as PullCounter;
 
-use dataflow::operators::{InputHandle, OutputHandle};
+use dataflow::operators::handles::{InputHandle, OutputHandle};
 use dataflow::operators::handles::{new_input_handle, new_output_handle};
 use dataflow::operators::capability::mint as mint_capability;
 


### PR DESCRIPTION
This PR changes `input::Handle` a bit, in particular allowing one to create it independently and then attach it to an input, in much the same way that `probe::Handle` and `probe_with()` work. The intent here is that code can be more idiomatic, with inputs defined and then used, rather than constructed in nested scopes and then returned.

For example, one can rewrite the fragment of `hello.rs` that currently looks like so:

```rust
let (mut input, probe) = worker.dataflow(move |scope| {
    let (input, stream) = scope.new_input();
    let probe = stream.exchange(|x| *x)
                      .inspect(move |x| println!("worker {}:\thello {}", index, x))
                      .probe();
    (input, probe)
});
```

as


```rust
let mut input = InputHandle::new();

let probe = worker.dataflow(|scope|
    scope.input_from(&mut input)
         .exchange(|x| *x)
         .inspect(move |x| println!("worker {}:\thello {}", index, x))
         .probe()
);
```

or more explicitly as

```rust
let mut input = InputHandle::new();
let mut probe = ProbeHandle::new();

worker.dataflow(|scope| {
    scope.input_from(&mut input)
         .exchange(|x| *x)
         .inspect(move |x| println!("worker {}:\thello {}", index, x))
         .probe_with(&mut probe);
});
```

These changes, as with the `probe_with` change, are intended to help clarify which things have a dependence on the dataflow scope and which do not. The input handle depends on the data type and timestamp type, but not on the scope. We can even go crazy and use it in multiple scopes, if that is appealing

```rust
let mut input = InputHandle::new();
let mut probe = ProbeHandle::new();

worker.dataflow(|scope| {
    scope.input_from(&mut input)
         .exchange(|x| *x)
         .inspect(move |x| println!("worker {}:\thello1 {}", index, x))
         .probe_with(&mut probe);
});

worker.dataflow(|scope| {
    scope.input_from(&mut input)
         .exchange(|x| *x)
         .inspect(move |x| println!("worker {}:\thello2 {}", index, x))
         .probe_with(&mut probe);
});
```

The `input::Handle` type is defined so that you can call `input_from` on an active input handle, even one into which data have been sent and whose timestamps have been advanced. Calling `input_from` only provides the records introduced after that call. It is not clear that this functionality is desirable, but you shouldn't be able to break things.

This PR includes a few other changes, and is technically breaking in that it changes the re-export of `operators::handles::InputHandle` as `operators::InputHandle`. This seemed fine internally, though others relying on it may be disappointed. Even if we want to re-export it, we should find a module that is more specific.

This PR also changes `ExchangeExtension` to just be `Exchange`. This had previously clashed with the `Exchange` pact, but .. anyone who wants to use both the `exchange` method and the exchange pact can rebind the pact using `as`.