### PR TITLE
make OutputHandle visible again

### DIFF
--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -58,7 +58,8 @@ pub mod count;
 
 // keep the handle constructors private
 mod handles;
-// pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
+// pub use self::handles::{InputHandle, FrontieredInputHandle};
+pub use self::handles::OutputHandle;
 
 mod notificator;
 pub use self::notificator::Notificator;


### PR DESCRIPTION
Without it, differential-dataflow does not compile.