### PR TITLE
collect generic operators in module

### DIFF
--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -3,7 +3,8 @@ extern crate timely;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::progress::timestamp::RootTimestamp;
 
-use timely::dataflow::operators::*;
+use timely::dataflow::operators::{LoopVariable, ConnectLoop};
+use timely::dataflow::operators::generic::unary::Unary;
 
 fn main() {
 

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -9,8 +9,10 @@ use rand::{Rng, SeedableRng, StdRng};
 use timely_sort::{RadixSorter, RadixSorterBase};
 use timely_sort::LSBRadixSorter as Sorter;
 
-use timely::dataflow::operators::*;
+use timely::dataflow::operators::{ToStream, Concat, LoopVariable, ConnectLoop};
+use timely::dataflow::operators::generic::binary::Binary;
 use timely::dataflow::channels::pact::Exchange;
+
 fn main() {
 
     // command-line args: numbers of nodes and edges in the random graph.

--- a/examples/distinct.rs
+++ b/examples/distinct.rs
@@ -2,7 +2,8 @@ extern crate timely;
 
 use std::collections::HashMap;
 
-use timely::dataflow::operators::{ToStream, Unary, Inspect};
+use timely::dataflow::operators::{ToStream, Inspect};
+use timely::dataflow::operators::generic::unary::Unary;
 use timely::dataflow::channels::pact::Pipeline;
 
 fn main() {

--- a/examples/unionfind.rs
+++ b/examples/unionfind.rs
@@ -8,7 +8,8 @@ use std::cmp::Ordering;
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
+use timely::dataflow::operators::{Input, Exchange, Probe};
+use timely::dataflow::operators::generic::unary::Unary;
 use timely::dataflow::channels::pact::Pipeline;
 
 fn main() {

--- a/src/dataflow/operators/aggregation/aggregate.rs
+++ b/src/dataflow/operators/aggregation/aggregate.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use ::{Data, ExchangeData};
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 use dataflow::channels::pact::Exchange;
 
 /// Generic intra-timestamp aggregation

--- a/src/dataflow/operators/aggregation/state_machine.rs
+++ b/src/dataflow/operators/aggregation/state_machine.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use ::{Data, ExchangeData};
 use order::PartialOrder;
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 use dataflow::channels::pact::Exchange;
 
 /// Generic state-transition machinery: each key has a state, and receives a sequence of events. 

--- a/src/dataflow/operators/concat.rs
+++ b/src/dataflow/operators/concat.rs
@@ -4,16 +4,7 @@
 use Data;
 use dataflow::channels::pact::Pipeline;
 use dataflow::{Stream, Scope};
-use dataflow::operators::binary::Binary;
-
-// NOTE : These used to have more exotic implementations that connected observers in a tangle.
-// NOTE : It was defective when used with the Observer protocol, because it just forwarded open and
-// NOTE : shut messages, without concern for the fact that there would be multiple opens and shuts,
-// NOTE : from each of its inputs. This implementation does more staging of data, but should be
-// NOTE : less wrong.
-
-// NOTE : Observers don't exist any more, so maybe it could become a horrible tangle again! :D
-// NOTE : Not clear that the tangle buys much, as buffers are simply passed along without copying.
+use dataflow::operators::generic::binary::Binary;
 
 /// Merge the contents of two streams.
 pub trait Concat<G: Scope, D: Data> {

--- a/src/dataflow/operators/count.rs
+++ b/src/dataflow/operators/count.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use Data;
 use dataflow::channels::pact::Pipeline;
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 
 use dataflow::channels::message::Content;
 

--- a/src/dataflow/operators/delay.rs
+++ b/src/dataflow/operators/delay.rs
@@ -8,7 +8,7 @@ use order::PartialOrder;
 use dataflow::channels::pact::Pipeline;
 use dataflow::channels::Content;
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 
 /// Methods to advance the timestamps of records or batches of records.
 pub trait Delay<G: Scope, D: Data> {
@@ -24,7 +24,8 @@ pub trait Delay<G: Scope, D: Data> {
     /// and delays each element `i` to time `RootTimestamp(i)`.
     ///
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Delay, Unary};
+    /// use timely::dataflow::operators::{ToStream, Delay};
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     /// use timely::progress::timestamp::RootTimestamp;
     ///
@@ -53,7 +54,8 @@ pub trait Delay<G: Scope, D: Data> {
     /// and delays each batch (there is just one) to time `RootTimestamp(1)`.
     ///
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Delay, Unary};
+    /// use timely::dataflow::operators::{ToStream, Delay};
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     /// use timely::progress::timestamp::RootTimestamp;
     ///

--- a/src/dataflow/operators/exchange.rs
+++ b/src/dataflow/operators/exchange.rs
@@ -4,7 +4,7 @@ use ::ExchangeData;
 use dataflow::channels::pact::Exchange as ExchangePact;
 use dataflow::channels::pact::TimeExchange as TimeExchangePact;
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 use progress::timestamp::Timestamp;
 
 /// Exchange records between workers.

--- a/src/dataflow/operators/filter.rs
+++ b/src/dataflow/operators/filter.rs
@@ -3,7 +3,7 @@
 use Data;
 use dataflow::channels::pact::Pipeline;
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 
 /// Extension trait for filtering.
 pub trait Filter<D: Data> {

--- a/src/dataflow/operators/generic/binary.rs
+++ b/src/dataflow/operators/generic/binary.rs
@@ -17,8 +17,8 @@ use dataflow::channels::pullers::counter::Counter as PullCounter;
 use dataflow::channels::pact::ParallelizationContract;
 use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 
-use dataflow::operators::handles::{InputHandle, OutputHandle};
-use dataflow::operators::handles::{new_input_handle, new_output_handle};
+use dataflow::operators::generic::handles::{InputHandle, OutputHandle};
+use dataflow::operators::generic::handles::{new_input_handle, new_output_handle};
 use dataflow::operators::capability::mint as mint_capability;
 
 use dataflow::{Stream, Scope};
@@ -31,7 +31,8 @@ pub trait Binary<G: Scope, D1: Data> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Binary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::binary::Binary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {
@@ -64,7 +65,8 @@ pub trait Binary<G: Scope, D1: Data> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Binary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::binary::Binary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -1,4 +1,7 @@
 //! Handles to an operator's input and output streams.
+//!
+//! These handles are used by the generic operator interfaces to allow user closures to interact as 
+//! the operator would with its input and output streams.
 
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -43,7 +46,8 @@ impl<'a, T: Timestamp, D> InputHandle<'a, T, D> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Unary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {
@@ -80,7 +84,8 @@ impl<'a, T: Timestamp, D> FrontieredInputHandle<'a, T, D> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Unary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {
@@ -133,7 +138,8 @@ impl<'a, T: Timestamp, D, P: Push<(T, Content<D>)>> OutputHandle<'a, T, D, P> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Unary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {

--- a/src/dataflow/operators/generic/mod.rs
+++ b/src/dataflow/operators/generic/mod.rs
@@ -1,0 +1,14 @@
+//! Generic operators defined by user-provided closures.
+
+pub mod unary;
+pub mod binary;
+pub mod operator;
+mod handles;
+mod notificator;
+
+pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
+pub use self::notificator::{Notificator, FrontierNotificator};
+
+pub use self::unary::Unary;
+pub use self::binary::Binary;
+pub use self::operator::{Operator, source};

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -55,7 +55,8 @@ impl<T: Timestamp> Notificator<T> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Unary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {
@@ -262,7 +263,8 @@ fn notificator_delivers_notifications_in_topo_order() {
 /// #Examples
 /// ```
 /// use std::collections::HashMap;
-/// use timely::dataflow::operators::{Input, Operator, Inspect, FrontierNotificator};
+/// use timely::dataflow::operators::{Input, Inspect, FrontierNotificator};
+/// use timely::dataflow::operators::generic::operator::Operator;
 /// use timely::dataflow::channels::pact::Pipeline;
 ///
 /// timely::execute(timely::Configuration::Thread, |worker| {
@@ -326,7 +328,8 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Operator, FrontierNotificator};
+    /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
+    /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -19,8 +19,8 @@ use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use dataflow::channels::pact::ParallelizationContract;
 use dataflow::channels::pullers::Counter as PullCounter;
 
-use dataflow::operators::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
-use dataflow::operators::handles::{new_input_handle, new_frontier_input_handle, new_output_handle};
+use dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
+use dataflow::operators::generic::handles::{new_input_handle, new_frontier_input_handle, new_output_handle};
 use dataflow::operators::capability::Capability;
 use dataflow::operators::capability::mint as mint_capability;
 
@@ -37,7 +37,8 @@ pub trait Operator<G: Scope, D1: Data> {
     /// #Examples
     /// ```
     /// use std::collections::HashMap;
-    /// use timely::dataflow::operators::{ToStream, Operator, FrontierNotificator};
+    /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
+    /// use timely::dataflow::operators::generic::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     /// use timely::progress::timestamp::RootTimestamp;
     ///
@@ -78,7 +79,8 @@ pub trait Operator<G: Scope, D1: Data> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Operator, FrontierNotificator};
+    /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
+    /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     /// use timely::progress::timestamp::RootTimestamp;
     /// use timely::dataflow::Scope;
@@ -112,7 +114,8 @@ pub trait Operator<G: Scope, D1: Data> {
     /// #Examples
     /// ```
     /// use std::collections::HashMap;
-    /// use timely::dataflow::operators::{Input, Operator, Inspect, FrontierNotificator};
+    /// use timely::dataflow::operators::{Input, Inspect, FrontierNotificator};
+    /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::execute(timely::Configuration::Thread, |worker| {
@@ -167,7 +170,8 @@ pub trait Operator<G: Scope, D1: Data> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Operator, Inspect, FrontierNotificator};
+    /// use timely::dataflow::operators::{ToStream, Inspect, FrontierNotificator};
+    /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     /// use timely::progress::timestamp::RootTimestamp;
     /// use timely::dataflow::Scope;
@@ -268,7 +272,7 @@ fn binary_base<G: Scope, D1: Data, D2: Data, D3: Data, P1, P2>(
 /// #Examples
 /// ```
 /// use timely::dataflow::operators::Inspect;
-/// use timely::dataflow::operators::operator::source;
+/// use timely::dataflow::operators::generic::operator::source;
 /// use timely::dataflow::Scope;
 ///
 /// timely::example(|scope| {

--- a/src/dataflow/operators/generic/unary.rs
+++ b/src/dataflow/operators/generic/unary.rs
@@ -15,8 +15,8 @@ use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use dataflow::channels::pact::ParallelizationContract;
 use dataflow::channels::pullers::Counter as PullCounter;
 
-use dataflow::operators::handles::{InputHandle, OutputHandle};
-use dataflow::operators::handles::{new_input_handle, new_output_handle};
+use dataflow::operators::generic::handles::{InputHandle, OutputHandle};
+use dataflow::operators::generic::handles::{new_input_handle, new_output_handle};
 use dataflow::operators::capability::mint as mint_capability;
 
 use ::Data;
@@ -31,7 +31,8 @@ pub trait Unary<G: Scope, D1: Data> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Unary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {
@@ -56,7 +57,8 @@ pub trait Unary<G: Scope, D1: Data> {
     ///
     /// #Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Unary};
+    /// use timely::dataflow::operators::ToStream;
+    /// use timely::dataflow::operators::generic::unary::Unary;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::example(|scope| {

--- a/src/dataflow/operators/inspect.rs
+++ b/src/dataflow/operators/inspect.rs
@@ -3,7 +3,7 @@
 use Data;
 use dataflow::channels::pact::Pipeline;
 use dataflow::{Stream, Scope};
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 
 /// Methods to inspect records and batches of records on a stream.
 pub trait Inspect<G: Scope, D: Data> {

--- a/src/dataflow/operators/map.rs
+++ b/src/dataflow/operators/map.rs
@@ -3,7 +3,7 @@
 use Data;
 use dataflow::{Stream, Scope};
 use dataflow::channels::pact::Pipeline;
-use dataflow::operators::unary::Unary;
+use dataflow::operators::generic::unary::Unary;
 
 /// Extension trait for `Stream`.
 pub trait Map<S: Scope, D: Data> {

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -4,12 +4,11 @@
 //! objects as output. Many of the operators provide simple, composable functionality. Some of the
 //! operators are more complicated, for use with advanced timely dataflow features.
 //!
-//! The [`Unary`](./unary/index.html) and [`Binary`](./binary/index.html) operators provide general
+//! The [`Unary`](./generic/unary/index.html) and [`Binary`](./generic/binary/index.html) operators provide general
 //! operators whose behavior can be supplied using closures accepting input and output handles.
 //! Most of the operators in this module are defined using these two general operators.
 
 pub use self::enterleave::{Enter, EnterAt, Leave};
-pub use self::unary::Unary;
 // pub use self::queue::*;
 pub use self::input::Input;
 pub use self::unordered_input::UnorderedInput;
@@ -19,21 +18,20 @@ pub use self::partition::Partition;
 pub use self::map::Map;
 pub use self::inspect::Inspect;
 pub use self::filter::Filter;
-pub use self::binary::Binary;
 pub use self::delay::Delay;
 pub use self::exchange::Exchange;
 pub use self::broadcast::Broadcast;
 pub use self::probe::Probe;
 pub use self::to_stream::ToStream;
 pub use self::capture::Capture;
-pub use self::operator::Operator;
+
+pub use self::generic::{Unary, Binary, Operator};
+pub use self::generic::{Notificator, FrontierNotificator};
 
 pub use self::reclock::Reclock;
 pub use self::count::Accumulate;
 
 pub mod enterleave;
-pub mod unary;
-// pub mod queue;
 pub mod input;
 pub mod unordered_input;
 pub mod feedback;
@@ -42,28 +40,18 @@ pub mod partition;
 pub mod map;
 pub mod inspect;
 pub mod filter;
-pub mod binary;
 pub mod delay;
 pub mod exchange;
 pub mod broadcast;
 pub mod probe;
 pub mod to_stream;
 pub mod capture;
-pub mod operator;
 
 pub mod aggregation;
+pub mod generic;
 
 pub mod reclock;
 pub mod count;
-
-// keep the handle constructors private
-mod handles;
-// pub use self::handles::{InputHandle, FrontieredInputHandle};
-pub use self::handles::OutputHandle;
-
-mod notificator;
-pub use self::notificator::Notificator;
-pub use self::notificator::FrontierNotificator;
 
 // keep "mint" module-private
 mod capability;

--- a/src/dataflow/operators/reclock.rs
+++ b/src/dataflow/operators/reclock.rs
@@ -4,7 +4,7 @@ use Data;
 use order::PartialOrder;
 use dataflow::{Stream, Scope};
 use dataflow::channels::pact::Pipeline;
-use dataflow::operators::binary::Binary;
+use dataflow::operators::generic::binary::Binary;
 
 /// Extension trait for reclocking a stream.
 pub trait Reclock<S: Scope, D: Data> {

--- a/src/dataflow/operators/to_stream.rs
+++ b/src/dataflow/operators/to_stream.rs
@@ -4,7 +4,7 @@ use progress::Timestamp;
 
 use Data;
 use dataflow::channels::Content;
-use dataflow::operators::operator::source;
+use dataflow::operators::generic::operator::source;
 use dataflow::{Stream, Scope};
 
 /// Converts to a timely `Stream`.


### PR DESCRIPTION
This PR moves various generic operators from the `timely::dataflow::operators` module to one called `generic` nested underneath. All previously visible types and traits exported in `operators` should be re-exported, but named modules are not spoofed (differential dataflow was overly specific about the location of `timely::dataflow::operators::operator::source`, and breaks; there is a branch correcting this that will be merged asap should this land).

Mostly, this PR is an exercise in trying to thin down the `operators` module so that one can more safely do blanket imports. My understanding is that blanket imports are naughty, but everyone wants to type

```rust
use timely::dataflow::operators::*;
```

rather than carefully enumerate all of the extension traits that they actually use. I think ideally we would have several logically coherent modules under `operators`, like `aggregation` is today. Should you want to use the generic operators to write your own, you can get everything you need with just:

```rust
use timely::dataflow::operators::generic::*;
```

Part of the problem was that blanket imports with many names in them seemed to start to lead to silent failures. For example, the `Input` trait was being clobbered by a similarly named type, and silently failing (or, the failures were "cannot find method `new_input()`" rather than "`Input` already defined"). the `InputHandle` type clashed with something else that I wrote, even though I didn't need it imported. 

I think the compartmentalization should make it easier to use classes of methods without worrying about name clashes as much, but I don't have a lot of direct experience organizing extension traits in Rust, so this might be a learning experience (e.g. "everything broke; you suck!").