### PR TITLE
book contents tested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/frankmcsherry/timely-dataflow.git"
 keywords = ["timely", "dataflow"]
 license = "MIT"
 
+build = "booktests.rs"
+
 [features]
 default=[]
 logging=[]
@@ -27,3 +29,7 @@ time="0.1.34"
 [dev-dependencies]
 getopts="0.2.14"
 rand="0.3.13"
+skeptic = "0.12"
+
+[build-dependencies]
+skeptic = "0.12"

--- a/booktests.rs
+++ b/booktests.rs
@@ -1,0 +1,10 @@
+extern crate skeptic;
+
+use skeptic::*;
+
+fn main() {
+    // skeptic::generate_doc_tests(&["mdbook/src/chapter_1_1.md"]);
+    let mut mdbook_files = markdown_files_of_directory("mdbook/src");
+    // mdbook_files.push("SUMMARY.md".to_owned());
+    generate_doc_tests(&mdbook_files);
+}

--- a/mdbook/src/SUMMARY.md
+++ b/mdbook/src/SUMMARY.md
@@ -10,8 +10,9 @@
 - [Building Timely Dataflows](./chapter_2.md)
     - [Creating Inputs](./chapter_2_1.md)
     - [Probing Outputs](./chapter_2_2.md)
-    - [Introducing Operators](./chapter_2_3.md)
-    - [Introducing Scopes](./chapter_2_4.md)
+    - [Adding Operators](./chapter_2_3.md)
+    - [Creating Operators](./chapter_2_4.md)
+    - [Iteration and Scopes](./chapter_2_5.md)
 
 - [Running Timely Dataflows](./chapter_3.md)
 

--- a/mdbook/src/chapter_1_1.md
+++ b/mdbook/src/chapter_1_1.md
@@ -8,7 +8,7 @@ Let's write an overly simple dataflow program. Remember our `examples/hello.rs` 
 
 Here is a reduced version of `examples/hello.rs` that just feeds data in to our dataflow, without paying any attention to progress made. In particular, we have removed the `probe()` operation, the resulting `probe` variable, and the use of `probe` to determine how long we should step the worker before introducing more data.
 
-```rust
+```rust,no_run
 extern crate timely;
 
 use timely::dataflow::InputHandle;
@@ -45,7 +45,7 @@ This program is a *dataflow program*. There are two dataflow operators here, `ex
 
 Importantly, we haven't imposed any constraints on how these operators need to run. We removed the code that caused the input to be delayed until a certain amount of progress had been made, and it shows in the results when we run with more than one worker:
 
-    Echidnatron% cargo run --example hello -- -w2
+Echidnatron% cargo run --example hello -- -w2
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w2`
     worker 1:	hello 1
@@ -66,7 +66,7 @@ What a mess. Nothing in our dataflow program requires that workers zero and one 
 
 However, this is only a mess if we are concerned about the order, and in many cases we are not. Imagine instead of just printing the number to the screen, we want to find out which numbers are prime and print *them* to the screen.
 
-```rust
+```rust,ignore
 .inspect(|x| {
     // we only need to test factors up to sqrt(x) 
     let limit = (*x as f64).sqrt() as u64;
@@ -105,6 +105,7 @@ The time is basically halved, from one minute to thirty seconds, which is a grea
 
 This is probably as good a time as any to tell you about Rust's `--release` flag. I haven't been using it up above to keep things simple, but adding the `--release` flag to cargo's arguments makes the compilation take a little longer, but the resulting program run a *lot* faster. Let's do that now, to get a sense for how much of a difference it makes:
 
+```ignore
     Echidnatron% time cargo run --release --example hello -- -w1 > output1.txt
         Finished release [optimized] target(s) in 0.0 secs
         Running `target/release/examples/hello -w1`
@@ -113,12 +114,13 @@ This is probably as good a time as any to tell you about Rust's `--release` flag
         Finished release [optimized] target(s) in 0.0 secs
         Running `target/release/examples/hello -w2`
     cargo run --release --example hello -- -w2 > output2.txt  0.73s user 0.05s system 165% cpu 0.474 total
+```
 
 That is about a 60x speed-up. The good news is that we are still getting approximately a 2x speed-up going from one worker to two, but you can see that dataflow programming does not magically extract all performance from your computer.
 
 This is also a fine time to point out that dataflow programming is not religion. There is an important part of our program up above that is imperative:
 
-```rust
+```ignore, rust
     let limit = (*x as f64).sqrt() as u64;
     if *x > 1 && (2 .. limit + 1).all(|i| x % i > 0) {
         println!("{} is prime", x);

--- a/mdbook/src/chapter_1_2.md
+++ b/mdbook/src/chapter_1_2.md
@@ -12,13 +12,13 @@ Remember from the dataflow section how when we remove the coordination from our 
 
 Let's change the program to print out the timestamp with each record. This shouldn't be very thrilling output, because the timestamp is exactly the same as the number itself, but that didn't have to be the case. We are just going to replace the line
 
-```rust
+```rust,ignore
 .inspect(move |x| println!("worker {}:\thello {}", index, x))
 ```
 
 with a slightly more complicated operator, `inspect_batch`.
 
-```rust
+```rust,ignore
 .inspect_batch(move |t,xs| {
     for x in xs.iter() {
         println!("worker {}:\thello {} @ {:?}", index, x, t)

--- a/mdbook/src/chapter_1_3.md
+++ b/mdbook/src/chapter_1_3.md
@@ -4,7 +4,7 @@ Both dataflow and timestamps are valuable in the own right, but when we bring th
 
 Let's recall that bit of code we commented out from `examples/hello.rs`, which had to do with consulting something named `probe`.
 
-```rust
+```rust,no_run
 extern crate timely;
 
 use timely::dataflow::InputHandle;
@@ -39,7 +39,7 @@ fn main() {
 
 We'll put the whole program up here, but there are really just two lines that deal with progress tracking:
 
-```rust
+```rust,ignore
 input.advance_to(round + 1);
 worker.step_while(|| probe.less_than(input.time()));
 ```

--- a/mdbook/src/chapter_2.md
+++ b/mdbook/src/chapter_2.md
@@ -1,0 +1,33 @@
+# Building Timely Dataflows
+
+Let's talk about how to create timely dataflows.
+
+This section will be a bit of a tour through the dataflow construction process, starting with getting data in to and out of a dataflow, through the main classes of operators you might like to use, as well as how to build your own operators.
+
+Everything to do with dataflow construction happens within the timely worker, and we'll want to write it all inside the closure we supply to timely for each worker:
+
+```rust,no_run
+extern crate timely;
+
+fn main() {
+    // initializes and runs a timely dataflow.
+    timely::execute_from_args(std::env::args(), |worker| {
+
+        // define a new dataflow
+        worker.dataflow::<(),_,_>(|scope| {
+
+            // WE ARE GOING TO WRITE THIS STUFF!!!
+
+        });
+
+    }).unwrap();
+}
+```
+
+Timely should keep us honest here, because we will need access to a dataflow scope (named `scope` in the example above) to create any dataflow operators. However, with that access we can start building up pretty exciting dataflows!
+
+You may have notice that we had to supply some weird `<(),_,_>` decorator to the call to `dataflow`, and why is that, huh? The `dataflow` method is "generic", in that it works with many different types of .. "things". In this case, we need to specify three types to use `dataflow`: the timestamp type it should use, the type of closure we are asking it to invoke, and the type of data we plan to return. In most cases Rust can use type inference to infer these without the `<...>` nonsense, but since we aren't *doing* anything in the dataflow, we didn't give it enough hints. Here we are saying "use timestamp type `()`", and the `_` is special and means: "figure it out yourself" using type inference.
+
+---
+
+**NOTE**: Timely very much assumes that you are going to build the same dataflow on each worker. You don't literally have to, in that you could build a dataflow from user input, or with a random number generator, things like that. Please don't! It will not be a good use of your time.

--- a/mdbook/src/chapter_2_1.md
+++ b/mdbook/src/chapter_2_1.md
@@ -1,0 +1,106 @@
+# Creating Inputs
+
+Let's start with the first thing we'll want for a dataflow computation: a source of data.
+
+Almost all operators in timely can only be defined from a source of data, with a few exceptions. One of those exceptions is the input operator. How do we get such an operator? As it turns out, there are some handy methods that dataflow scopes provide for us. One of these is `new_input()`. 
+
+```rust,no_run
+extern crate timely;
+
+use timely::dataflow::operators::Input;
+
+fn main() {
+    // initializes and runs a timely dataflow.
+    timely::execute_from_args(std::env::args(), |worker| {
+
+        // define a new dataflow
+        worker.dataflow::<(),_,_>(|scope| {
+
+            // WE ARE GOING TO WRITE THIS STUFF!!!
+            let (handle, stream) = scope.new_input::<String>();
+
+        });
+
+    }).unwrap();
+}
+```
+
+The call to `new_input()` returns two things: a `handle` that we the Rust program can use to supply data to the dataflow, and a `stream` of that data once it has been introduced into the dataflow. We are going to want to return `handle` upward so that our worker can actually use it once we've finished building the dataflow, and we'll probably want to use `stream` as the basis of further computation.
+
+The `dataflow()` method we invoked can return things. Anything our closure returns, the method will return. This is handy if we want to extract the handle so that we can use it after the dataflow is constructed. We might reasonably write:
+
+```rust,no_run
+extern crate timely;
+
+use timely::dataflow::operators::Input;
+
+fn main() {
+    // initializes and runs a timely dataflow.
+    timely::execute_from_args(std::env::args(), |worker| {
+
+        // define a new dataflow
+        let mut handle = worker.dataflow::<(),_,_>(|scope| {
+            let (handle, stream) = scope.new_input::<String>();
+            handle
+        });
+
+    }).unwrap();
+}
+```
+
+In Rust you return things just by having them be the last expression in a sequence, and *not* putting a semicolon after them. Or rather, if you put a semicolon after the last item you return the result, which happens to be the type `()`.
+
+Up about we've bound the handle to another variable named `handle` using `let mut handle = ...`. This is how we explain to Rust that we are taking ownership of the returned handle, and moreover that we might plan on doing some mutation with this handle (if we want to send some data at it, for example).
+
+There are other ways of constructing inputs, that vary according to taste. Another way you can accomplish what we've just done above is to first create `handle` outside of the dataflow, unattached to any stream, and then use the `input_from` method to bind it to a stream:
+
+```rust,no_run
+extern crate timely;
+
+use timely::dataflow::InputHandle;
+use timely::dataflow::operators::Input;
+
+fn main() {
+    // initializes and runs a timely dataflow.
+    timely::execute_from_args(std::env::args(), |worker| {
+
+        // define `handle` before the dataflow.
+        let mut handle = InputHandle::<(), String>::new();
+
+        // define a new dataflow
+        worker.dataflow(|scope| {
+            // attach `handle` in the dataflow.
+            scope.input_from(&mut handle);
+        });
+
+    }).unwrap();
+}
+```
+
+This approach is clearer for some, but could also be error-prone: you might create a handle and forget to attach it. I suppose at the same time you could create an input stream and forget to use it (like we did above), so this distinction is perhaps to taste.
+
+Also notice that while we do have to specific `<(), String>` to create the new input handle (timestamp and data types), we no longer need to do so for the `dataflow` method. Independently, you might wonder why the `<...>` stuff goes before the method here; it's just a matter that the *type* `InputHandle` is generic and we are specifying its parameters (not the `new` method's), whereas the *method* `dataflow` is generic and we were specifying its parameters (not the scope's).
+
+## Non-interactive inputs
+
+You can also create non-interactive inputs, if you'd like part of your computation to run even without your help. The `to_stream` method is defined on any iterator, and introduces all of the data the iterator produces into a dataflow stream.
+
+```rust,no_run
+extern crate timely;
+
+use timely::dataflow::operators::ToStream;
+
+fn main() {
+    // initializes and runs a timely dataflow.
+    timely::execute_from_args(std::env::args(), |worker| {
+
+        // define a new dataflow
+        worker.dataflow::<(),_,_>(|scope| {
+            // attach `handle` in the dataflow.
+            (0 .. 10).map(|x| x.to_string())
+                     .to_stream(scope);
+        });
+
+    }).unwrap();
+}
+```

--- a/mdbook/src/chapter_2_2.md
+++ b/mdbook/src/chapter_2_2.md
@@ -1,0 +1,1 @@
+# Probing Outputs

--- a/mdbook/src/chapter_2_3.md
+++ b/mdbook/src/chapter_2_3.md
@@ -1,0 +1,1 @@
+# Introducing Operators

--- a/mdbook/src/chapter_2_4.md
+++ b/mdbook/src/chapter_2_4.md
@@ -1,0 +1,1 @@
+# Introducing Scopes

--- a/mdbook/src/chapter_2_5.md
+++ b/mdbook/src/chapter_2_5.md
@@ -1,0 +1,1 @@
+# Iteration and Scopes

--- a/mdbook/src/chapter_3.md
+++ b/mdbook/src/chapter_3.md
@@ -1,0 +1,1 @@
+# Running Timely Dataflows

--- a/mdbook/src/chapter_4.md
+++ b/mdbook/src/chapter_4.md
@@ -1,0 +1,1 @@
+# Internals

--- a/mdbook/src/chapter_4_1.md
+++ b/mdbook/src/chapter_4_1.md
@@ -1,0 +1,1 @@
+# Communication

--- a/mdbook/src/chapter_4_2.md
+++ b/mdbook/src/chapter_4_2.md
@@ -1,0 +1,1 @@
+# Progress Tracking

--- a/mdbook/src/introduction.md
+++ b/mdbook/src/introduction.md
@@ -12,7 +12,7 @@ Timely dataflow means to capture a large number of idioms, and so it is a bit tr
 
 The following complete program initializes a timely dataflow computation, in which participants can supply a stream of numbers which are exchanged between the workers based on their value. Workers print to the screen when they see numbers. You can also find this as [`examples/hello.rs`](https://github.com/frankmcsherry/timely-dataflow/blob/master/examples/hello.rs) in the [timely dataflow repository](https://github.com/frankmcsherry/timely-dataflow/tree/master/examples).
 
-```rust
+```rust,no_run
 extern crate timely;
 
 use timely::dataflow::InputHandle;

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This PR sets up testing of book contents as part of `cargo test`. It should error if examples no longer build. The examples shouldn't *run*, because .. well I've used the `no_run` decorator and I'm hoping that saves some time and some numbers 0 through 9 in the output. But I've missed at least one so far.

Anyhow, it will be good to have this as part of the test workflow, so that there are always-current documentation about how to build up timely dataflow computations.