### PR TITLE
Fn to FnOnce

### DIFF
--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -69,7 +69,7 @@ pub trait Operator<G: Scope, D1: Data> {
     fn unary_frontier<D2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> Stream<G, D2>
     where
         D2: Data,
-        B: Fn(Capability<G::Timestamp>) -> L,
+        B: FnOnce(Capability<G::Timestamp>) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1>, &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
@@ -103,7 +103,7 @@ pub trait Operator<G: Scope, D1: Data> {
     fn unary<D2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> Stream<G, D2>
     where
         D2: Data,
-        B: Fn(Capability<G::Timestamp>) -> L,
+        B: FnOnce(Capability<G::Timestamp>) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1>, &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
@@ -157,7 +157,7 @@ pub trait Operator<G: Scope, D1: Data> {
     where
         D2: Data,
         D3: Data,
-        B: Fn(Capability<G::Timestamp>) -> L,
+        B: FnOnce(Capability<G::Timestamp>) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1>,
                  &mut FrontieredInputHandle<G::Timestamp, D2>,
                  &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
@@ -199,7 +199,7 @@ pub trait Operator<G: Scope, D1: Data> {
     where
         D2: Data,
         D3: Data,
-        B: Fn(Capability<G::Timestamp>) -> L,
+        B: FnOnce(Capability<G::Timestamp>) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1>, &mut InputHandle<G::Timestamp, D2>, &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;


### PR DESCRIPTION
This modifies the "builder" closure in the `operator.rs` from `Fn` to `FnOnce`. This allows it to take ownership from its containing scope, for example if you wanted to move a `HashMap` defined outside the closure into the closure.