### PR TITLE
Split out a SubgraphBuilder type that exists only during the dataflow construction phase.

### DIFF
--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 
-use progress::{Timestamp, Operate, Subgraph};
+use progress::{Timestamp, Operate, SubgraphBuilder};
 use progress::nested::{Source, Target};
 use timely_communication::Allocate;
 
@@ -48,7 +48,7 @@ pub trait Scope: ScopeParent {
 
     /// Creates a new `Subgraph` with timestamp `T`. Used by `scoped`, but unlikely to be
     /// commonly useful to end users.
-    fn new_subscope<T: Timestamp>(&mut self) -> Subgraph<Self::Timestamp, T>;
+    fn new_subscope<T: Timestamp>(&mut self) -> SubgraphBuilder<Self::Timestamp, T>;
 
     /// Creates a `Subgraph` from a closure acting on a `Child` scope, and returning
     /// whatever the closure returns.
@@ -85,7 +85,8 @@ pub trait Scope: ScopeParent {
         };
 
         let index = subscope.borrow().index;
-        self.add_operator_with_index(subscope.into_inner(), index);
+        let subscope = subscope.into_inner().build(self);
+        self.add_operator_with_index(subscope, index);
 
         result
     }

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -1,8 +1,6 @@
 //! Hierarchical organization of timely dataflow graphs.
 
-use std::cell::RefCell;
-
-use progress::{Timestamp, Operate, SubgraphBuilder};
+use progress::{Timestamp, Operate};
 use progress::nested::{Source, Target};
 use timely_communication::Allocate;
 
@@ -46,10 +44,6 @@ pub trait Scope: ScopeParent {
     /// child, as happens in subgraph creation.
     fn add_operator_with_index<SC: Operate<Self::Timestamp>+'static>(&mut self, scope: SC, index: usize);
 
-    /// Creates a new `Subgraph` with timestamp `T`. Used by `scoped`, but unlikely to be
-    /// commonly useful to end users.
-    fn new_subscope<T: Timestamp>(&mut self) -> SubgraphBuilder<Self::Timestamp, T>;
-
     /// Creates a `Subgraph` from a closure acting on a `Child` scope, and returning
     /// whatever the closure returns.
     ///
@@ -72,22 +66,5 @@ pub trait Scope: ScopeParent {
     ///     });
     /// });
     /// ```
-    #[inline]
-    fn scoped<T: Timestamp, R, F:FnOnce(&mut Child<Self, T>)->R>(&mut self, func: F) -> R {
-        let subscope = RefCell::new(self.new_subscope());
-
-        let result = {
-            let mut builder = Child {
-                subgraph: &subscope,
-                parent: self.clone(),
-            };
-            func(&mut builder)
-        };
-
-        let index = subscope.borrow().index;
-        let subscope = subscope.into_inner().build(self);
-        self.add_operator_with_index(subscope, index);
-
-        result
-    }
+    fn scoped<T: Timestamp, R, F:FnOnce(&mut Child<Self, T>)->R>(&mut self, func: F) -> R;
 }

--- a/src/dataflow/scopes/root.rs
+++ b/src/dataflow/scopes/root.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::any::Any;
 
 use progress::timestamp::RootTimestamp;
-use progress::{Timestamp, Operate, Subgraph};
+use progress::{Timestamp, Operate, SubgraphBuilder};
 use timely_communication::{Allocate, Data};
 use {Push, Pull};
 
@@ -84,7 +84,7 @@ impl<A: Allocate> Root<A> {
 
         let addr = vec![self.allocator.borrow().index()];
         let dataflow_index = self.allocate_dataflow_index();
-        let subscope = Subgraph::new_from(&mut (*self.allocator.borrow_mut()), dataflow_index, addr);
+        let subscope = SubgraphBuilder::new_from(dataflow_index, addr);
         let subscope = RefCell::new(subscope);
 
         let result = {
@@ -95,7 +95,7 @@ impl<A: Allocate> Root<A> {
             func(&mut resources, &mut builder)
         };
 
-        let mut operator = subscope.into_inner();
+        let mut operator = subscope.into_inner().build(&mut *self.allocator.borrow_mut());
 
         operator.get_internal_summary();
         operator.set_external_summary(Vec::new(), &mut []);

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -1,7 +1,7 @@
 //! Progress tracking mechanisms to support notification in timely dataflow
 
 pub use self::operate::Operate;
-pub use self::nested::{Subgraph, Source, Target};
+pub use self::nested::{Subgraph, SubgraphBuilder, Source, Target};
 pub use self::timestamp::{Timestamp, PathSummary};
 pub use self::change_batch::ChangeBatch;
 pub use self::frontier::Antichain;

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -1,6 +1,6 @@
 //! Coordination of progress information between a scope-as-operator and its children operators.
 
-pub use self::subgraph::Subgraph;
+pub use self::subgraph::{Subgraph, SubgraphBuilder};
 pub use self::subgraph::{Source, Target};
 pub use self::summary::Summary;
 

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -49,6 +49,38 @@ pub struct Target {
     pub port: usize, 
 }
 
+/// A builder structure for initializing `Subgraph`s.
+///
+/// This collects all the information necessary to get a `Subgraph` up and
+/// running, and is important largely through its `build` method which
+/// actually creates a `Subgraph`.
+pub struct SubgraphBuilder<TOuter: Timestamp, TInner: Timestamp> {
+    /// The name of this subgraph.
+    pub name: String,
+
+    /// A sequence of integers uniquely identifying the subgraph.
+    pub path: Vec<usize>,
+
+    /// The index assigned to the subgraph by its parent.
+    pub index: usize,
+
+    inputs: usize,
+    outputs: usize,
+
+    // handles to the children of the scope. index i corresponds to entry i-1, unless things change.
+    children: Vec<PerOperatorState<Product<TOuter, TInner>>>,
+    child_count: usize,
+
+    edge_stash: Vec<(Source, Target)>,
+
+    // shared state written to by the datapath, counting records entering this subgraph instance.
+    input_messages: Vec<Rc<RefCell<ChangeBatch<Product<TOuter, TInner>>>>>,
+
+    // expressed capabilities, used to filter changes against.
+    output_capabilities: Vec<MutableAntichain<TOuter>>,
+
+}
+
 /// A dataflow subgraph.
 ///
 /// The subgraph type contains the infrastructure required to describe the topology of and track
@@ -68,9 +100,6 @@ pub struct Subgraph<TOuter:Timestamp, TInner:Timestamp> {
 
     // handles to the children of the scope. index i corresponds to entry i-1, unless things change.
     children: Vec<PerOperatorState<Product<TOuter, TInner>>>,
-    child_count: usize,
-
-    edge_stash: Vec<(Source, Target)>,
 
     // shared state written to by the datapath, counting records entering this subgraph instance.
     input_messages: Vec<Rc<RefCell<ChangeBatch<Product<TOuter, TInner>>>>>,
@@ -105,20 +134,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
     fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<TOuter::Summary>>>, Vec<ChangeBatch<TOuter>>) {
 
         // println!("in GIS for subgraph: {:?}", self.path);
-
-        // at this point, the subgraph is frozen. we should initialize any internal state which
-        // may have been determined after construction (e.g. the numbers of inputs and outputs).
-        // we also need to determine what to return as a summary and initial capabilities, which
-        // will depend on child summaries and capabilities, as well as edges in the subgraph.
-
-        // perhaps first check that the children are saney identified
-        self.children.sort_by(|x,y| x.index.cmp(&y.index));
-        assert!(self.children.iter().enumerate().all(|(i,x)| i == x.index));
-
-        while let Some((source, target)) = self.edge_stash.pop() {
-            // println!("  edge: {:?}", (source, target));
-            self.children[source.index].edges[source.port].push(target);
-        }
 
         // set up a bit of information about the "0th" child, reflecting the subgraph's external
         // connections
@@ -491,6 +506,103 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
     }
 }
 
+impl<TOuter: Timestamp, TInner: Timestamp> SubgraphBuilder<TOuter, TInner> {
+    /// Allocates a new input to the subgraph and returns the assigned index.
+    pub fn new_input(&mut self, shared_counts: Rc<RefCell<ChangeBatch<Product<TOuter, TInner>>>>) -> usize {
+        self.inputs += 1;
+        self.input_messages.push(shared_counts);
+        self.children[0].add_output();
+        self.inputs - 1
+    }
+
+    /// Allocates a new output from the subgraph and returns the assigned index.
+    pub fn new_output(&mut self) -> usize {
+        self.outputs += 1;
+        self.output_capabilities.push(MutableAntichain::new());
+        self.children[0].add_input();
+        self.outputs - 1
+    }
+
+    /// Introduces a dependence from the source to the target.
+    ///
+    /// This method does not effect data movement, but rather reveals to the progress tracking infrastructure
+    /// that messages produced by `source` should be expected to be consumed at `target`.
+    pub fn connect(&mut self, source: Source, target: Target) {
+        self.edge_stash.push((source, target));
+    }
+
+    /// Creates a new Subgraph from a channel allocator and "descriptive" indices.
+    pub fn new_from(index: usize, mut path: Vec<usize>) -> SubgraphBuilder<TOuter, TInner> {
+        path.push(index);
+
+        let children = vec![PerOperatorState::empty(path.clone())];
+
+        SubgraphBuilder {
+            name:                   "Subgraph".into(),
+            path:                   path,
+            index:                  index,
+
+            inputs:                 Default::default(),
+            outputs:                Default::default(),
+
+            children:               children,
+            child_count:            1,
+            edge_stash: vec![],
+
+            input_messages:         Default::default(),
+            output_capabilities:    Default::default(),
+        }
+    }
+
+    /// Allocates a new child identifier, for later use.
+    pub fn allocate_child_id(&mut self) -> usize {
+        self.child_count += 1;
+        self.child_count - 1
+    }
+
+    /// Adds a new child to the subgraph.
+    pub fn add_child(&mut self, child: Box<Operate<Product<TOuter, TInner>>>, index: usize, identifier: usize) {
+        self.children.push(PerOperatorState::new(child, index, self.path.clone(), identifier))
+    }
+
+    /// Now that initialization is complete, actually build a subgraph.
+    pub fn build<A: Allocate>(mut self, allocator: &mut A) -> Subgraph<TOuter, TInner> {
+        // at this point, the subgraph is frozen. we should initialize any internal state which
+        // may have been determined after construction (e.g. the numbers of inputs and outputs).
+        // we also need to determine what to return as a summary and initial capabilities, which
+        // will depend on child summaries and capabilities, as well as edges in the subgraph.
+
+        // perhaps first check that the children are saney identified
+        self.children.sort_by(|x,y| x.index.cmp(&y.index));
+        assert!(self.children.iter().enumerate().all(|(i,x)| i == x.index));
+
+        for (source, target) in self.edge_stash {
+            // println!("  edge: {:?}", (source, target));
+            self.children[source.index].edges[source.port].push(target);
+        }
+
+        let progcaster = Progcaster::new(allocator);
+
+        Subgraph {
+            name: self.name,
+            path: self.path,
+            index: self.index,
+            inputs: self.inputs,
+            outputs: self.outputs,
+            children: self.children,
+            input_messages: self.input_messages,
+            output_capabilities: self.output_capabilities,
+
+            pointstamps:               Default::default(),
+            local_pointstamp_messages: ChangeBatch::new(),
+            local_pointstamp_internal: ChangeBatch::new(),
+            final_pointstamp_messages: ChangeBatch::new(),
+            final_pointstamp_internal: ChangeBatch::new(),
+            progcaster:                progcaster,
+        }
+    }
+}
+
 impl<TOuter: Timestamp, TInner: Timestamp> Subgraph<TOuter, TInner> {
 
     // pushes pointstamps to scopes using self.*_summaries; clears pre-push counts.
@@ -643,72 +755,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> Subgraph<TOuter, TInner> {
         //         }
         //     }
         // }
-    }
-
-    /// Allocates a new input to the subgraph and returns the assigned index.
-    pub fn new_input(&mut self, shared_counts: Rc<RefCell<ChangeBatch<Product<TOuter, TInner>>>>) -> usize {
-        self.inputs += 1;
-        self.input_messages.push(shared_counts);
-        self.children[0].add_output();
-        self.inputs - 1
-    }
-
-    /// Allocates a new output from the subgraph and returns the assigned index.
-    pub fn new_output(&mut self) -> usize {
-        self.outputs += 1;
-        self.output_capabilities.push(MutableAntichain::new());
-        self.children[0].add_input();
-        self.outputs - 1
-    }
-
-    /// Introduces a dependence from the source to the target.
-    ///
-    /// This method does not effect data movement, but rather reveals to the progress tracking infrastructure
-    /// that messages produced by `source` should be expected to be consumed at `target`.
-    pub fn connect(&mut self, source: Source, target: Target) {
-        self.edge_stash.push((source, target));
-    }
-
-    /// Creates a new Subgraph from a channel allocator and "descriptive" indices.
-    pub fn new_from<A: Allocate>(allocator: &mut A, index: usize, mut path: Vec<usize>) -> Subgraph<TOuter, TInner> {
-        let progcaster = Progcaster::new(allocator);
-        path.push(index);
-
-        let children = vec![PerOperatorState::empty(path.clone())];
-
-        Subgraph {
-            name:                   "Subgraph".into(),
-            path:                   path,
-            index:                  index,
-
-            inputs:                 Default::default(),
-            outputs:                Default::default(),
-
-            children:               children,
-            child_count:            1,
-            edge_stash: vec![],
-
-            input_messages:         Default::default(),
-            output_capabilities:    Default::default(),
-
-            pointstamps:            Default::default(),
-            local_pointstamp_messages:    ChangeBatch::new(),
-            local_pointstamp_internal:    ChangeBatch::new(),
-            final_pointstamp_messages:    ChangeBatch::new(),
-            final_pointstamp_internal:    ChangeBatch::new(),
-            progcaster:             progcaster,
-        }
-    }
-
-    /// Allocates a new child identifier, for later use.
-    pub fn allocate_child_id(&mut self) -> usize {
-        self.child_count += 1;
-        self.child_count - 1
-    }
-
-    /// Adds a new child to the subgraph.
-    pub fn add_child(&mut self, child: Box<Operate<Product<TOuter, TInner>>>, index: usize, identifier: usize) {
-        self.children.push(PerOperatorState::new(child, index, self.path.clone(), identifier))
     }
 }
 

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -62,7 +62,7 @@ pub struct SubgraphBuilder<TOuter: Timestamp, TInner: Timestamp> {
     pub path: Vec<usize>,
 
     /// The index assigned to the subgraph by its parent.
-    pub index: usize,
+    index: usize,
 
     inputs: usize,
     outputs: usize,
@@ -507,20 +507,20 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
 }
 
 impl<TOuter: Timestamp, TInner: Timestamp> SubgraphBuilder<TOuter, TInner> {
-    /// Allocates a new input to the subgraph and returns the assigned index.
-    pub fn new_input(&mut self, shared_counts: Rc<RefCell<ChangeBatch<Product<TOuter, TInner>>>>) -> usize {
+    /// Allocates a new input to the subgraph and returns the target to that input in the outer graph.
+    pub fn new_input(&mut self, shared_counts: Rc<RefCell<ChangeBatch<Product<TOuter, TInner>>>>) -> Target {
         self.inputs += 1;
         self.input_messages.push(shared_counts);
         self.children[0].add_output();
-        self.inputs - 1
+        Target { index: self.index, port: self.inputs - 1 }
     }
 
-    /// Allocates a new output from the subgraph and returns the assigned index.
-    pub fn new_output(&mut self) -> usize {
+    /// Allocates a new output from the subgraph and returns the source of that output in the outer graph.
+    pub fn new_output(&mut self) -> Source {
         self.outputs += 1;
         self.output_capabilities.push(MutableAntichain::new());
         self.children[0].add_input();
-        self.outputs - 1
+        Source { index: self.index, port: self.outputs - 1 }
     }
 
     /// Introduces a dependence from the source to the target.


### PR DESCRIPTION
This splits out a `SubgraphBuilder` type from `Subgraph`, which allows representing things differently and doing initialization routines while building the dataflow graph without worrying about interleaving those things with actual execution.