### PR TITLE
remove Event::Start

### DIFF
--- a/src/dataflow/operators/capture/capture.rs
+++ b/src/dataflow/operators/capture/capture.rs
@@ -132,7 +132,6 @@ impl<S: Scope, D: Data> Capture<S::Timestamp, D> for Stream<S, D> {
                     started = true;
                 }
                 if !frontier[0].is_empty() {
-                    println!("frontier: {:?}", frontier[0]);
                     let to_send = ::std::mem::replace(&mut frontier[0], ChangeBatch::new());
                     event_pusher1.borrow_mut().push(Event::Progress(to_send.into_inner()));
                 }

--- a/src/dataflow/operators/capture/capture.rs
+++ b/src/dataflow/operators/capture/capture.rs
@@ -132,6 +132,7 @@ impl<S: Scope, D: Data> Capture<S::Timestamp, D> for Stream<S, D> {
                     started = true;
                 }
                 if !frontier[0].is_empty() {
+                    println!("frontier: {:?}", frontier[0]);
                     let to_send = ::std::mem::replace(&mut frontier[0], ChangeBatch::new());
                     event_pusher1.borrow_mut().push(Event::Progress(to_send.into_inner()));
                 }

--- a/src/dataflow/operators/capture/replay.rs
+++ b/src/dataflow/operators/capture/replay.rs
@@ -81,7 +81,6 @@ where I : IntoIterator,
                 for event_stream in event_streams.iter_mut() {
                     while let Some(event) = event_stream.next() {
                         match *event {
-                            Event::Start => { },
                             Event::Progress(ref vec) => {
                                 internal[0].extend(vec.iter().cloned());
                             },


### PR DESCRIPTION
This PR removes the `Event::Start` variant from `Event`. It was present so that the linked list implementation could have a valid entry for its head, but that seemed like a bad reason to have such an event, and the linked list implementation was fixed. We could imagine having `Event::Start` and `Event::End` to give structure to the stream, but they are meant to be self-describing as it is (the start is the first event, and it ends when it releases its final capability).