### PR TITLE
notificator should be monotonic

### DIFF
--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -1,17 +1,18 @@
-use std::collections::VecDeque;
-
 use progress::frontier::MutableAntichain;
 use progress::Timestamp;
 use dataflow::operators::Capability;
 
 /// Tracks requests for notification and delivers available notifications.
 ///
-/// `Notificator` is meant to manage the delivery of requested notifications in the presence of
-/// inputs that may have outstanding messages to deliver. The notificator tracks the frontiers,
-/// as presented from the outside, for each input. Requested notifications can be served only
-/// once there are no frontier elements less-or-equal to them, and there are no other pending
-/// notification requests less than them. Each with be less-or-equal to itself, so we want to
-/// dodge that corner case.
+/// A `Notificator` represents a dynamic set of notifications and a fixed notification frontier.
+/// One can interact with one by requesting notification with `notify_at`, and retrieving notifications
+/// with `for_each` and `next`. The next notification to be delivered will be the available notification
+/// with the least timestamp, with the implication that the notifications will be non-decreasing as long
+/// as you do not request notifications at times prior to those that have already been delivered.
+///
+/// Notification requests persist across uses of `Notificator`, and it may help to think of `Notificator`
+/// as a notification *session*. However, idiomatically it seems you mostly want to restrict your usage
+/// to such sessions, which is why this is the main notificator type.
 pub struct Notificator<'a, T: Timestamp> {
     frontiers: &'a [&'a MutableAntichain<T>],
     inner: &'a mut FrontierNotificator<T>,
@@ -19,33 +20,22 @@ pub struct Notificator<'a, T: Timestamp> {
 
 impl<'a, T: Timestamp> Notificator<'a, T> {
     /// Allocates a new `Notificator`.
-    pub fn new(
-        frontiers: &'a [&'a MutableAntichain<T>],
-        inner: &'a mut FrontierNotificator<T>) -> Notificator<'a, T> {
+    ///
+    /// This is more commonly accomplished using `input.monotonic(frontiers)`.
+    pub fn new(frontiers: &'a [&'a MutableAntichain<T>], inner: &'a mut FrontierNotificator<T>) -> Self {
+        inner.make_available(frontiers);
         Notificator {
             frontiers: frontiers,
             inner: inner,
         }
     }
 
-    // /// Updates the `Notificator`'s frontiers from a `ChangeBatch` per input.
-    // pub fn update_frontier_from_cm(&mut self, count_map: &mut [ChangeBatch<T>]) {
-    //     while self.frontiers.len() < count_map.len() {
-    //         self.frontiers.push(MutableAntichain::new());
-    //     }
-
-    //     for (index, counts) in count_map.iter_mut().enumerate() {
-    //         self.frontiers[index].update_iter(counts.drain());
-    //     }
-    // }
-
     /// Reveals the elements in the frontier of the indicated input.
     pub fn frontier(&self, input: usize) -> &[T] {
         self.frontiers[input].frontier()
     }
 
-    /// Requests a notification at the time associated with capability `cap`. Takes ownership of
-    /// the capability.
+    /// Requests a notification at the time associated with capability `cap`.
     ///
     /// In order to request a notification at future timestamp, obtain a capability for the new
     /// timestamp first, as show in the example.
@@ -73,10 +63,10 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     /// ```
     #[inline]
     pub fn notify_at(&mut self, cap: Capability<T>) {
-        self.inner.notify_at(cap);
+        self.inner.notify_at_frontiered(cap, self.frontiers);
     }
 
-    /// Repeatedly calls `logic` till exhaustion of the available notifications.
+    /// Repeatedly calls `logic` until exhaustion of the available notifications.
     ///
     /// `logic` receives a capability for `t`, the timestamp being notified and a `count`
     /// representing how many capabilities were requested for that specific timestamp.
@@ -105,90 +95,20 @@ impl<'a, T: Timestamp> Iterator for Notificator<'a, T> {
     }
 }
 
-// impl<T: Timestamp> Notificator<T> {
-
-//     // appends elements of `self.pending` not `greater_equal` to `self.frontier` into `self.available`.
-//     fn make_available(&mut self) {
-
-//         // By invariant, nothing in self.available is greater_equal anything in self.pending.
-//         // It should be safe to append any ordered subset of self.pending to self.available,
-//         // in that the sequence of capabilities in self.available will remain non-decreasing.
-
-//         if self.pending.len() > 0 {
-//             self.pending.sort_by(|x,y| x.0.time().cmp(y.0.time()));
-//             for i in 0 .. self.pending.len() - 1 {
-//                 if self.pending[i].0.time() == self.pending[i+1].0.time() {
-//                     self.pending[i+1].1 += self.pending[i].1;
-//                     self.pending[i].1 = 0;
-//                 }
-//             }
-//             self.pending.retain(|x| x.1 > 0);
-
-//             for i in 0 .. self.pending.len() {
-//                 if self.frontier.iter().all(|f| !f.less_equal(&self.pending[i].0)) {
-//                     // TODO : This clones a capability, whereas we could move it instead.
-//                     self.available.push_back((self.pending[i].0.clone(), self.pending[i].1));
-//                     self.pending[i].1 = 0;
-//                 }
-//             }
-//             self.pending.retain(|x| x.1 > 0);
-//         }
-//     }
-// }
-
-trait DrainIntoIf<T> {
-    /// Invokes "P" on each element of "source" (exactly once) and moves the matching values to
-    /// "target". Ordering is not preserved.
-    fn drain_into_if<P>(&mut self, target: &mut Vec<T>, p: P) -> () where P: FnMut(&T) -> bool;
-}
-
-impl<T> DrainIntoIf<T> for Vec<T> {
-    fn drain_into_if<P>(&mut self, target: &mut Vec<T>, mut p: P) -> () where P: FnMut(&T) -> bool {
-        let mut i = 0;
-        while i < self.len() {
-            let matches = {
-                let v = &mut **self;
-                p(&v[i])
-            };
-            if matches {
-                target.push(self.swap_remove(i));
-            } else {
-                i += 1;
-            }
-        }
-    }
-}
-
-#[test]
-fn drain_into_if_behaves_correctly() {
-    let mut v = vec![3, 10, 4, 5, 13, 7, 2, 1];
-    let mut v1 = Vec::new();
-    v.drain_into_if(&mut v1, |x| x >= &5);
-    v.sort();
-    v1.sort();
-    assert!(v == vec![1, 2, 3, 4]);
-    assert!(v1 == vec![5, 7, 10, 13]);
-}
-
 #[test]
 fn notificator_delivers_notifications_in_topo_order() {
     use std::rc::Rc;
     use std::cell::RefCell;
-    // use order::PartialOrder;
     use progress::ChangeBatch;
     use progress::frontier::MutableAntichain;
     use progress::nested::product::Product;
-    // use progress::timestamp::RootTimestamp;
     use dataflow::operators::capability::mint as mint_capability;
-    // fn ts_from_tuple(t: (u64, u64)) -> Product<Product<RootTimestamp, u64>, u64> {
-    //     let (a, b) = t;
-    //     Product::new(RootTimestamp::new(a), b)
-    // }
-    let mut frontier_notificator = FrontierNotificator::new();
+
     let mut frontier = MutableAntichain::new_bottom(Product::new(0, 0));
 
+    let root_capability = mint_capability(Product::new(0,0), Rc::new(RefCell::new(ChangeBatch::new())));
+
     // notificator.update_frontier_from_cm(&mut vec![ChangeBatch::new_from(ts_from_tuple((0, 0)), 1)]);
-    let internal_changes = Rc::new(RefCell::new(ChangeBatch::new()));
     let times = vec![
         Product::new(3, 5),
         Product::new(5, 4),
@@ -197,45 +117,51 @@ fn notificator_delivers_notifications_in_topo_order() {
         Product::new(1, 1),
         Product::new(5, 4),
         Product::new(6, 0),
+        Product::new(6, 2),
         Product::new(5, 8),
-    ].into_iter().map(|ts| mint_capability(ts, internal_changes.clone()));
-    for t in times {
-        frontier_notificator.notify_at(t);
+    ];
+
+    // create a raw notificator with pending notifications at the times above.
+    let mut frontier_notificator = FrontierNotificator::from(times.iter().map(|t| root_capability.delayed(t)));
+
+    // the frontier is initially (0,0), and so we should deliver no notifications.
+    assert!(frontier_notificator.monotonic(&[&frontier]).next().is_none());
+
+    // advance the frontier to [(5,7), (6,0)], opening up some notifications.
+    frontier.update_iter(vec![(Product::new(0,0),-1), (Product::new(5,7), 1), (Product::new(6,1), 1)]);
+
+    {
+        let frontiers = [&frontier];
+        let mut notificator = frontier_notificator.monotonic(&frontiers);
+
+        // we should deliver the following available notifications, in this order.
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(1,1));
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(1,2));
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(3,5));
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(5,4));
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(6,0));
+        assert_eq!(notificator.next(), None);
     }
-    // notificator.update_frontier_from_cm(&mut {
-    //     let mut cm = ChangeBatch::new();
-    //     cm.update(ts_from_tuple((0, 0)), -1);
-    //     cm.update(ts_from_tuple((5, 7)), 1);
-    //     cm.update(ts_from_tuple((6, 0)), 1);
-    //     vec![cm]
-    // });
-    // Drains all the available notifications and checks they're being delivered in some
-    // topological ordering. Also checks that the counts returned by .next() match the expected
-    // counts.
-    fn check_notifications<T: Timestamp>(
-        notificator: &mut Notificator<T>,
-        expected_counts: Vec<T>) {
 
-        // collect all notifications
-        let mut notified = notificator.by_ref().map(|(t, _)| t.time().clone()).collect::<Vec<_>>();
-        notified.sort();
-        assert_eq!(notified, expected_counts);
+    // advance the frontier to [(6,10)] opening up all remaining notifications.
+    frontier.update_iter(vec![(Product::new(5,7), -1), (Product::new(6,1), -1), (Product::new(6,10), 1)]);
+
+    {
+        let frontiers = [&frontier];
+        let mut notificator = frontier_notificator.monotonic(&frontiers);
+
+        // the first available notification should be (5,8). Note: before (6,0) in the total order, but not
+        // in the partial order. We don't make the promise that we respect the total order.
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(5, 8));
+
+        // add a new notification, mid notification session.
+        notificator.notify_at(root_capability.delayed(&Product::new(5,9)));
+
+        // we expect to see (5,9) before we see (6,2) before we see None.
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(5,9));
+        assert_eq!(notificator.next().unwrap().0.time(), &Product::new(6,2));
+        assert_eq!(notificator.next(), None);
     }
-
-    frontier.update_iter(vec![(Product::new(0,0),-1), (Product::new(5,7), 1), (Product::new(6,0), 1)]);
-    check_notifications(&mut Notificator::new(&[&frontier], &mut frontier_notificator), vec![
-        Product::new(1, 1),
-        Product::new(1, 2),
-        Product::new(3, 5),
-        Product::new(5, 4),
-    ]);
-
-    frontier.update_iter(vec![(Product::new(5,7), -1), (Product::new(6,0), -1), (Product::new(6,10), 1)]);
-    check_notifications(&mut Notificator::new(&[&frontier], &mut frontier_notificator), vec![
-        Product::new(5, 8),
-        Product::new(6, 0),
-    ]);
-
 }
 
 /// Tracks requests for notification and delivers available notifications.
@@ -293,15 +219,23 @@ fn notificator_delivers_notifications_in_topo_order() {
 /// ```
 pub struct FrontierNotificator<T: Timestamp> {
     pending: Vec<(Capability<T>, u64)>,
-    available: VecDeque<Capability<T>>,
+    available: ::std::collections::BinaryHeap<OrderReversed<T>>,
 }
 
 impl<T: Timestamp> FrontierNotificator<T> {
-    /// Allocates a new `Notificator`.
-    pub fn new() -> FrontierNotificator<T> {
+    /// Allocates a new `FrontierNotificator`.
+    pub fn new() -> Self {
         FrontierNotificator {
             pending: Vec::new(),
-            available: VecDeque::new(),
+            available: ::std::collections::BinaryHeap::new(),
+        }
+    }
+
+    /// Allocates a new `FrontierNotificator` with initial capabilities.
+    pub fn from<I: IntoIterator<Item=Capability<T>>>(iter: I) -> Self {
+        FrontierNotificator {
+            pending: iter.into_iter().map(|x| (x,1)).collect(),
+            available: ::std::collections::BinaryHeap::new(),
         }
     }
 
@@ -336,24 +270,28 @@ impl<T: Timestamp> FrontierNotificator<T> {
     /// });
     /// ```
     #[inline]
-    pub fn notify_at(&mut self, cap: Capability<T>) {
-        self.pending.push((cap, 1));
+    pub fn notify_at<'a>(&mut self, cap: Capability<T>) {
+        self.pending.push((cap,1));
     }
 
-    /// Iterate over the notifications made available by inspecting the frontiers.
-    pub fn drain<'a>(&'a mut self, frontiers: &'a [&'a MutableAntichain<T>]) -> ::std::collections::vec_deque::Drain<'a, Capability<T>> {
-        self.make_available(frontiers);
-        self.available.drain(..)
+    /// Requests a notification at the time associated with capability `cap`.
+    ///
+    /// The method takes list of frontiers from which it determines if the capability is immediately available.
+    /// When used with the same frontier as `make_available`, this method can ensure that notifications are
+    /// non-decreasing. Simply using `notify_at` will only insert new notifications into the list of pending
+    /// notifications, which are only re-examine with calls to `make_available`.
+    #[inline]
+    pub fn notify_at_frontiered<'a>(&mut self, cap: Capability<T>, frontiers: &'a [&'a MutableAntichain<T>]) {
+        if frontiers.iter().all(|f| !f.less_equal(cap.time())) {
+            self.available.push(OrderReversed::new(cap));
+        }
+        else {
+            self.pending.push((cap,1));
+        }
     }
-    // FrontierNotificatorIterator<'a, T> {
-    //     FrontierNotificatorIterator {
-    //         notificator: self,
-    //         frontiers: frontiers,
-    //     }
-    // }
 
-    // appends elements of `self.pending` not `greater_equal` to `self.frontier` into `self.available`.
-    fn make_available<'a>(&mut self, frontiers: &'a [&'a MutableAntichain<T>]) {
+    /// Enables pending notifications not in advance of any element of `frontiers`.
+    pub fn make_available<'a>(&mut self, frontiers: &'a [&'a MutableAntichain<T>]) {
 
         // By invariant, nothing in self.available is greater_equal anything in self.pending.
         // It should be safe to append any ordered subset of self.pending to self.available,
@@ -373,7 +311,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
             for i in 0 .. self.pending.len() {
                 if frontiers.iter().all(|f| !f.less_equal(&self.pending[i].0)) {
                     // TODO : This clones a capability, whereas we could move it instead.
-                    self.available.push_back(self.pending[i].0.clone());
+                    self.available.push(OrderReversed::new(self.pending[i].0.clone()));
                     self.pending[i].1 = 0;
                 }
             }
@@ -381,12 +319,20 @@ impl<T: Timestamp> FrontierNotificator<T> {
         }
     }
 
+    /// Returns the next available capability with respect to the supplied frontiers, if one exists.
+    ///
+    /// In the interest of efficiency, this method may yield capabilities in decreasing order, in certain
+    /// circumstances. If you want to iterate through capabilities with an in-order guarantee, either (i)
+    /// use `for_each` 
     #[inline]
-    fn next<'a>(&mut self, frontiers: &'a [&'a MutableAntichain<T>]) -> Option<Capability<T>> {
+    pub fn next<'a>(&mut self, frontiers: &'a [&'a MutableAntichain<T>]) -> Option<Capability<T>> {
         if self.available.is_empty() {
             self.make_available(frontiers);
         }
-        self.available.pop_front()
+        self.available.pop().map(|front| {
+            while self.available.peek() == Some(&front) { self.available.pop(); }
+            front.element
+        })
     }
 
     /// Repeatedly calls `logic` till exhaustion of the notifications made available by inspecting
@@ -396,29 +342,39 @@ impl<T: Timestamp> FrontierNotificator<T> {
     #[inline]
     pub fn for_each<'a, F: FnMut(Capability<T>, &mut FrontierNotificator<T>)>(&mut self, frontiers: &'a [&'a MutableAntichain<T>], mut logic: F) {
         self.make_available(frontiers);
-        while let Some(cap) = self.available.pop_front() {
+        while let Some(cap) = self.next(frontiers) {
             ::logging::log(&::logging::GUARDED_PROGRESS, true);
             logic(cap, self);
             ::logging::log(&::logging::GUARDED_PROGRESS, false);
         }
     }
+
+    /// Creates a notificator session in which delivered notification will be non-decreasing.
+    ///
+    /// This implementation can be emulated with judicious use of `make_available` and `notify_at_frontiered`,
+    /// in the event that `Notificator` provides too restrictive an interface.
+    #[inline]
+    pub fn monotonic<'a>(&'a mut self, frontiers: &'a [&'a MutableAntichain<T>]) -> Notificator<'a, T> {
+        Notificator::new(frontiers, self)
+    }
 }
 
-// pub struct FrontierNotificatorIterator<'a, T: Timestamp, I> {
-//     notificator: &'a mut FrontierNotificator<T>,
-//     frontiers: &'a [&'a MutableAntichain<T>],
-// }
+#[derive(PartialEq, Eq)]
+struct OrderReversed<T: Timestamp> {
+    element: Capability<T>,
+}
 
-// impl<'a, T: Timestamp> Iterator for FrontierNotificatorIterator<'a, T> {
-//     type Item = Capability<T>;
+impl<T: Timestamp> OrderReversed<T> {
+    fn new(element: Capability<T>) -> Self { OrderReversed { element: element } }
+}
 
-//     /// Retrieve the next available notification.
-//     ///
-//     /// Returns `None` if no notification is available. Returns `Some(cap, count)` otherwise:
-//     /// `cap` is a a capability for `t` - the timestamp being notified - and `count` represents
-//     /// how many notifications (out of those requested) are being delivered for that specific
-//     /// timestamp.
-//     fn next(&mut self) -> Option<Capability<T>> {
-//         self.notificator.next(self.frontiers.iter())
-//     }
-// }
+impl<T: Timestamp> PartialOrd for OrderReversed<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+        other.element.time().partial_cmp(self.element.time())
+    }
+}
+impl<T: Timestamp> Ord for OrderReversed<T> {
+    fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+        other.element.time().cmp(&self.element.time())
+    }
+}


### PR DESCRIPTION
This PR alters the implementation of `Notificator` and `FrontierNotificator` in an attempt to provide non-decreasing notifications even when one re-requests notifications mid-iteration. This involves a priority queue where previously there was a vanilla queue, but otherwise isn't too complicated.

One other conceptual change is that `Notificator` is more clearly "a notification session with respect to a fixed set of frontiers". The correctness of the monotonicity is based on frontier being fixed, which it is for `Notificator` and which it is not for `FrontierNotificator`. There are probably additional idiomatic improvements here, likely around deprecating `FrontierNotificator` or some of its methods.