### PR TITLE
Output wrapper

### DIFF
--- a/src/dataflow/operators/generic/builder_rc.rs
+++ b/src/dataflow/operators/generic/builder_rc.rs
@@ -65,7 +65,6 @@ impl<G: Scope> OperatorBuilder<G> {
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
     pub fn new_output<D: Data>(&mut self) -> (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, Stream<G, D>) {
-    // (PushBuffer<G::Timestamp, D, PushCounter<G::Timestamp, D, Tee<G::Timestamp, D>>>, Stream<G, D>) {
 
         let (tee, stream) = self.builder.new_output();
 

--- a/src/dataflow/operators/generic/builder_rc.rs
+++ b/src/dataflow/operators/generic/builder_rc.rs
@@ -18,7 +18,7 @@ use dataflow::channels::pullers::Counter as PullCounter;
 use dataflow::operators::capability::Capability;
 use dataflow::operators::capability::mint as mint_capability;
 
-use dataflow::operators::generic::handles::{InputHandle, new_input_handle};
+use dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
 
 use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
 
@@ -64,14 +64,15 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_output<D: Data>(&mut self) -> (PushBuffer<G::Timestamp, D, PushCounter<G::Timestamp, D, Tee<G::Timestamp, D>>>, Stream<G, D>) {
+    pub fn new_output<D: Data>(&mut self) -> (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, Stream<G, D>) {
+    // (PushBuffer<G::Timestamp, D, PushCounter<G::Timestamp, D, Tee<G::Timestamp, D>>>, Stream<G, D>) {
 
         let (tee, stream) = self.builder.new_output();
 
         let mut buffer = PushBuffer::new(PushCounter::new(tee));
         self.produced.push(buffer.inner().produced().clone());
 
-        (buffer, stream)
+        (OutputWrapper::new(buffer), stream)
     }
 
     /// Creates an operator implementation from supplied logic constructor.

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -132,6 +132,24 @@ pub fn new_frontier_input_handle<'a, T: Timestamp, D: 'a, P: Pull<(T, Content<D>
     }
 }
 
+
+/// An owned instance of an output buffer.
+pub struct OutputWrapper<T: Timestamp, D, P: Push<(T, Content<D>)>> {
+    push_buffer: Buffer<T, D, PushCounter<T, D, P>>
+}
+
+impl<T: Timestamp, D, P: Push<(T, Content<D>)>> OutputWrapper<T, D, P> {
+    pub fn new(buffer: Buffer<T, D, PushCounter<T, D, P>>) -> Self {
+        OutputWrapper {
+            push_buffer: buffer
+        }
+    }
+    pub fn activate(&mut self) -> OutputHandle<T, D, P> {
+        new_output_handle(&mut self.push_buffer)
+    }
+}
+
+
 /// Handle to an operator's output stream.
 pub struct OutputHandle<'a, T: Timestamp, D: 'a, P: Push<(T, Content<D>)>+'a> {
     push_buffer: &'a mut Buffer<T, D, PushCounter<T, D, P>>,

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -5,7 +5,7 @@ use dataflow::channels::pushers::Tee;
 use dataflow::channels::pact::ParallelizationContract;
 
 use dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
-use dataflow::operators::generic::handles::{new_frontier_input_handle, new_output_handle};
+use dataflow::operators::generic::handles::{new_frontier_input_handle};
 use dataflow::operators::capability::Capability;
 
 use ::Data;
@@ -243,7 +243,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             let mut logic = constructor(capability);
             move |frontiers| {
                 let mut input_handle = new_frontier_input_handle(&mut input, &frontiers[0]);
-                let mut output_handle = output.activate();//new_output_handle(&mut output);
+                let mut output_handle = output.activate();
                 logic(&mut input_handle, &mut output_handle);        
             }
         });
@@ -268,7 +268,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         builder.build(move |capability| {
             let mut logic = constructor(capability);
             move |_frontiers| {
-                let mut output_handle = output.activate();//new_output_handle(&mut output);
+                let mut output_handle = output.activate();
                 logic(&mut input, &mut output_handle);        
             }
         });
@@ -298,7 +298,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             move |frontiers| {
                 let mut input1_handle = new_frontier_input_handle(&mut input1, &frontiers[0]);
                 let mut input2_handle = new_frontier_input_handle(&mut input2, &frontiers[1]);
-                let mut output_handle = output.activate();//new_output_handle(&mut output);
+                let mut output_handle = output.activate();
                 logic(&mut input1_handle, &mut input2_handle, &mut output_handle);        
             }
         });
@@ -327,7 +327,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         builder.build(move |capability| {
             let mut logic = constructor(capability);
             move |_frontiers| {
-                let mut output_handle = output.activate();//new_output_handle(&mut output);
+                let mut output_handle = output.activate();
                 logic(&mut input1, &mut input2, &mut output_handle);        
             }
         });

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -243,7 +243,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             let mut logic = constructor(capability);
             move |frontiers| {
                 let mut input_handle = new_frontier_input_handle(&mut input, &frontiers[0]);
-                let mut output_handle = new_output_handle(&mut output);
+                let mut output_handle = output.activate();//new_output_handle(&mut output);
                 logic(&mut input_handle, &mut output_handle);        
             }
         });
@@ -268,7 +268,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         builder.build(move |capability| {
             let mut logic = constructor(capability);
             move |_frontiers| {
-                let mut output_handle = new_output_handle(&mut output);
+                let mut output_handle = output.activate();//new_output_handle(&mut output);
                 logic(&mut input, &mut output_handle);        
             }
         });
@@ -298,7 +298,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             move |frontiers| {
                 let mut input1_handle = new_frontier_input_handle(&mut input1, &frontiers[0]);
                 let mut input2_handle = new_frontier_input_handle(&mut input2, &frontiers[1]);
-                let mut output_handle = new_output_handle(&mut output);
+                let mut output_handle = output.activate();//new_output_handle(&mut output);
                 logic(&mut input1_handle, &mut input2_handle, &mut output_handle);        
             }
         });
@@ -327,7 +327,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         builder.build(move |capability| {
             let mut logic = constructor(capability);
             move |_frontiers| {
-                let mut output_handle = new_output_handle(&mut output);
+                let mut output_handle = output.activate();//new_output_handle(&mut output);
                 logic(&mut input1, &mut input2, &mut output_handle);        
             }
         });
@@ -403,7 +403,7 @@ where
     builder.build(|capability| {
         let mut logic = constructor(capability);
         move |_frontier| {
-            logic(&mut new_output_handle(&mut output));        
+            logic(&mut output.activate());
         }
     });
 


### PR DESCRIPTION
This PR alters the results of `builder_rc`s `new_output` method. It was previously a raw buffer meant for pushing records, with the hope that you would wrap it in an `OutputHandle`. That hope was undercut by the `handles` module being private.

Now instead, the result type is not a raw buffer but a wrapper that supports only `activate` which returns the appropriately wrapped `OutputHandle`. This handle ensures that you use capabilities, and it calls `cease` in its drop implementation to ensure buffers are flushed.