### PR TITLE
LoopVariable doc typo fix

### DIFF
--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -24,8 +24,8 @@ pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
     /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
     ///
     /// The resulting `Stream` will have its data defined by a future call to `connect_loop` with
-    /// its `Handle` passed as an argument. Data will be passed through the stream will have their
-    /// timestampsas advanced by `summary`, and will be dropped if the result exceeds `limit`.
+    /// its `Handle` passed as an argument. Data passed through the stream will have their
+    /// timestamps advanced by `summary`, and will be dropped if the result exceeds `limit`.
     ///
     /// #Examples
     /// ```


### PR DESCRIPTION
Just a small typo in the LoopVariable docs.