### PR TITLE
Stateful progress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "timely"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "A low-latency data-parallel dataflow system in Rust"
@@ -15,18 +15,15 @@ license = "MIT"
 
 #build = "booktests.rs"
 
-[features]
-default=[]
-
 [dependencies]
-abomonation = { git = "https://github.com/frankmcsherry/abomonation" }
-abomonation_derive = { git = "https://github.com/mystor/abomonation_derive.git" }
-timely_sort="0.1.6"
-timely_communication = { version = "0.1.8", path = "./communication" }
+abomonation = "0.5"
+abomonation_derive = "0.3"
+timely_communication = { version = "0.5", path = "./communication" }
 byteorder="0.4.2"
 time="0.1.34"
 
 [dev-dependencies]
+timely_sort="0.1.6"
 getopts="0.2.14"
 rand="0.3.13"
 #skeptic = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 [dependencies]
 abomonation = "0.5"
 abomonation_derive = "0.3"
-timely_communication = { version = "0.5", path = "./communication" }
+timely_communication = "0.5"
 byteorder="0.4.2"
 time="0.1.34"
 

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timely_communication"
-version = "0.1.8"
+version = "0.5.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "Communication layer for timely dataflow"
@@ -19,8 +19,8 @@ default=[] # ["logging"]
 byteorder="0.4.2"
 getopts="0.2.14"
 time="0.1.34"
-abomonation = { git = "https://github.com/frankmcsherry/abomonation" }
-abomonation_derive = { git = "https://github.com/mystor/abomonation_derive.git" }
+abomonation = "0.5"
+abomonation_derive = "0.3"
 
 [profile.release]
 opt-level = 3

--- a/communication/examples/hello.rs
+++ b/communication/examples/hello.rs
@@ -4,12 +4,13 @@ fn main() {
 
     // extract the configuration from user-supplied arguments, initialize the computation.
     let config = timely_communication::Configuration::from_args(std::env::args()).unwrap();
-    let guards = timely_communication::initialize(config, |mut allocator| {
+    let logger = ::std::sync::Arc::new(|_| timely_communication::logging::BufferingLogger::new_inactive());
+    let guards = timely_communication::initialize(config, logger, |mut allocator| {
 
         println!("worker {} of {} started", allocator.index(), allocator.peers());
 
         // allocates pair of senders list and one receiver.
-        let (mut senders, mut receiver) = allocator.allocate();
+        let (mut senders, mut receiver, _) = allocator.allocate();
 
         // send typed data along each channel
         for i in 0 .. allocator.peers() {

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -19,12 +19,15 @@
 //! // configure for two threads, just one process.
 //! let config = timely_communication::Configuration::Process(2);
 //!
+//! // create a source of inactive loggers.
+//! let logger = ::std::sync::Arc::new(|_| timely_communication::logging::BufferingLogger::new_inactive());
+//!
 //! // initializes communication, spawns workers
-//! let guards = timely_communication::initialize(config, |mut allocator| {
+//! let guards = timely_communication::initialize(config, logger, |mut allocator| {
 //!     println!("worker {} started", allocator.index());
 //!
 //!     // allocates pair of senders list and one receiver.
-//!     let (mut senders, mut receiver) = allocator.allocate();
+//!     let (mut senders, mut receiver, _) = allocator.allocate();
 //!
 //!     // send typed data along each channel
 //!     senders[0].send(format!("hello, {}", 0));

--- a/communication/src/networking.rs
+++ b/communication/src/networking.rs
@@ -86,11 +86,7 @@ impl<R: Read> BinaryReceiver<R> {
             channels: Receiver<((usize,
             usize),
             Sender<Vec<u8>>)>,
-            process: usize,
-            index: usize,
-            threads: usize,
             log_sender: ::logging::CommsLogger) -> BinaryReceiver<R> {
-        eprintln!("process {}, index {}, threads {}", process, index, threads);
         BinaryReceiver {
             reader:     reader,
             buffer:     vec![0u8; 1 << 20],
@@ -154,7 +150,7 @@ struct BinarySender<W: Write> {
 }
 
 impl<W: Write> BinarySender<W> {
-    fn new(writer: W, sources: Receiver<(MessageHeader, Vec<u8>)>, _process: usize, _index: usize, log_sender: ::logging::CommsLogger) -> BinarySender<W> {
+    fn new(writer: W, sources: Receiver<(MessageHeader, Vec<u8>)>, log_sender: ::logging::CommsLogger) -> BinarySender<W> {
         BinarySender {
             writer:     writer,
             sources:    sources,
@@ -272,8 +268,6 @@ pub fn initialize_networking(
                                           });
                                           let mut sender = BinarySender::new(BufWriter::with_capacity(1 << 20, stream),
                                                                              sender_channels_r,
-                                                                             my_index,
-                                                                             index,
                                                                              log_sender);
                                           sender.send_loop()
                                       }).unwrap();
@@ -291,9 +285,6 @@ pub fn initialize_networking(
                                           });
                                           let mut recver = BinaryReceiver::new(stream,
                                                                                reader_channels_r,
-                                                                               my_index,
-                                                                               index,
-                                                                               threads,
                                                                                log_sender);
                                           recver.recv_loop()
                                       }).unwrap();

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -1,0 +1,138 @@
+extern crate timely;
+
+fn main() {
+    let nodes: usize = std::env::args().nth(1).unwrap().parse().unwrap();
+    let rounds: usize = std::env::args().nth(2).unwrap().parse().unwrap();
+
+    test_alt(nodes, rounds);
+    test_neu(nodes, rounds);
+}
+
+
+fn test_alt(nodes: usize, rounds: usize) {
+
+    use timely::progress::frontier::Antichain;
+    use timely::progress::nested::subgraph::{Source, Target};
+    use timely::progress::nested::reachability::{Builder, Tracker};
+
+    // This test means to exercise the efficiency of the tracker by performing local changes and expecting
+    // that it will respond efficiently.
+
+    // allocate a new empty topology builder.
+    let mut builder = Builder::<usize>::new();
+     
+    // Each node with one input connected to one output.
+    for index in 1 .. nodes {
+        builder.add_node(index - 1, 1, 1, vec![vec![Antichain::from_elem(0)]]);
+    }
+    builder.add_node(nodes - 1, 1, 1, vec![vec![Antichain::from_elem(1)]]);
+
+    // Connect nodes in sequence, looping around to the first from the last.
+    for index in 1 .. nodes {
+        builder.add_edge(Source { index: index - 1, port: 0 }, Target { index: index, port: 0 } );
+    }
+    builder.add_edge(Source { index: nodes - 1, port: 0 }, Target { index: 0, port: 0 } );
+
+    // Construct a reachability tracker.
+    let mut tracker = Tracker::allocate_from(builder.summarize());
+
+    let timer = ::std::time::Instant::now();
+
+    tracker.update_target(Target { index: 0, port: 0 }, 0, 1);
+    tracker.propagate_all();
+    for index in 0 .. nodes { tracker.pushed_mut(index).iter_mut().for_each(|x| { x.drain(); }); }
+
+    for round in 0 .. rounds {
+
+        for index in 1 .. nodes {
+            tracker.update_target(Target { index: index - 1, port: 0 }, round, -1);
+            tracker.update_target(Target { index: index, port: 0 }, round, 1);
+            tracker.propagate_all();
+            for index in 0 .. nodes { tracker.pushed_mut(index).iter_mut().for_each(|x| { x.drain(); }); }
+        }
+
+        tracker.update_target(Target { index: nodes - 1, port: 0 }, round, -1);
+        tracker.update_target(Target { index: 0, port: 0 }, round + 1, 1);
+        tracker.propagate_all();
+        for index in 0 .. nodes { tracker.pushed_mut(index).iter_mut().for_each(|x| { x.drain(); }); }
+    }
+
+    let elapsed = timer.elapsed();
+    println!("Reachability (alt) elapsed for {} nodes; avg: {:?}, total: {:?}", nodes, elapsed / ((nodes * rounds) as u32), elapsed);
+
+    let timer = ::std::time::Instant::now();
+    for round in rounds .. 2 * rounds {
+
+        tracker.update_target(Target { index: 0, port: 0 }, round, -1);
+        tracker.update_target(Target { index: 0, port: 0 }, round + 1, 1);
+        tracker.propagate_all();
+        for index in 0 .. nodes { tracker.pushed_mut(index).iter_mut().for_each(|x| { x.drain(); }); }
+    }
+
+    let elapsed = timer.elapsed();
+    println!("Reachability (alt) elapsed for {} nodes; avg: {:?}, total: {:?}", nodes, elapsed / (rounds as u32), elapsed);
+}
+
+fn test_neu(nodes: usize, rounds: usize) {
+
+    use timely::progress::frontier::Antichain;
+    use timely::progress::nested::subgraph::{Source, Target};
+    use timely::progress::nested::reachability_neu::Builder;
+
+    // This test means to exercise the efficiency of the tracker by performing local changes and expecting
+    // that it will respond efficiently.
+
+    // allocate a new empty topology builder.
+    let mut builder = Builder::<usize>::new();
+     
+    // Each node with one input connected to one output.
+    for index in 1 .. nodes {
+        builder.add_node(index - 1, 1, 1, vec![vec![Antichain::from_elem(0)]]);
+    }
+    builder.add_node(nodes - 1, 1, 1, vec![vec![Antichain::from_elem(1)]]);
+
+    // Connect nodes in sequence, looping around to the first from the last.
+    for index in 1 .. nodes {
+        builder.add_edge(Source { index: index - 1, port: 0 }, Target { index: index, port: 0 } );
+    }
+    builder.add_edge(Source { index: nodes - 1, port: 0 }, Target { index: 0, port: 0 } );
+
+    // Construct a reachability tracker.
+    let mut tracker = builder.build();
+
+    let timer = ::std::time::Instant::now();
+
+    tracker.update_target(Target { index: 0, port: 0 }, 0, 1);
+    tracker.propagate_all();
+    tracker.pushed().drain();
+
+    for round in 0 .. rounds {
+
+        for index in 1 .. nodes {
+            tracker.update_target(Target { index: index - 1, port: 0 }, round, -1);
+            tracker.update_target(Target { index: index, port: 0 }, round, 1);
+            tracker.propagate_all();
+            tracker.pushed().drain();
+        }
+
+        tracker.update_target(Target { index: nodes - 1, port: 0 }, round, -1);
+        tracker.update_target(Target { index: 0, port: 0 }, round + 1, 1);
+        tracker.propagate_all();
+        tracker.pushed().drain();
+    }
+
+    let elapsed = timer.elapsed();
+    println!("Reachability (neu) elapsed for {} nodes; avg: {:?}, total: {:?}", nodes, elapsed / ((nodes * rounds) as u32), elapsed);
+
+    let timer = ::std::time::Instant::now();
+    for round in rounds .. 2 * rounds {
+
+        tracker.update_target(Target { index: 0, port: 0 }, round, -1);
+        tracker.update_target(Target { index: 0, port: 0 }, round + 1, 1);
+        tracker.propagate_all();
+        tracker.pushed().drain();
+    }
+
+    let elapsed = timer.elapsed();
+    println!("Reachability (neu) elapsed for {} nodes; avg: {:?}, total: {:?}", nodes, elapsed / (rounds as u32), elapsed);
+}

--- a/src/dataflow/operators/capture/capture.rs
+++ b/src/dataflow/operators/capture/capture.rs
@@ -90,6 +90,8 @@ pub trait Capture<T: Timestamp, D: Data> {
     ///     let send = TcpStream::connect("127.0.0.1:8000").unwrap();
     ///     let recv = list.incoming().next().unwrap().unwrap();
     ///
+    ///     recv.set_nonblocking(true).unwrap();
+    ///
     ///     worker.dataflow::<u64,_,_>(|scope1|
     ///         (0..10u64)
     ///             .to_stream(scope1)
@@ -127,6 +129,7 @@ impl<S: Scope, D: Data> Capture<S::Timestamp, D> for Stream<S, D> {
 
         builder.build(
             move |frontier| {
+
                 if !started {
                     frontier[0].update(Default::default(), -1);
                     started = true;

--- a/src/dataflow/operators/capture/mod.rs
+++ b/src/dataflow/operators/capture/mod.rs
@@ -57,6 +57,8 @@
 //!     let send = TcpStream::connect("127.0.0.1:8000").unwrap();
 //!     let recv = list.incoming().next().unwrap().unwrap();
 //!
+//!     recv.set_nonblocking(true).unwrap();
+//!
 //!     worker.dataflow::<u64,_,_>(|scope1|
 //!         (0..10u64)
 //!             .to_stream(scope1)

--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -192,7 +192,7 @@ mod tests {
             for round in 0..10 {
                 assert!(!probe.done());
                 assert!(probe.less_equal(&RootTimestamp::new(round)));
-                assert!(!probe.less_than(&RootTimestamp::new(round)));
+                // assert!(!probe.less_than(&RootTimestamp::new(round)));
                 assert!(probe.less_than(&RootTimestamp::new(round + 1)));
                 input.advance_to(round + 1);
                 worker.step();
@@ -202,6 +202,9 @@ mod tests {
             input.close();
 
             // finish off any remaining work
+            worker.step();
+            worker.step();
+            worker.step();
             worker.step();
             assert!(probe.done());
         }).unwrap();

--- a/src/progress/change_batch.rs
+++ b/src/progress/change_batch.rs
@@ -122,6 +122,7 @@ impl<T:Ord> ChangeBatch<T> {
     /// }
     /// assert!(!batch.is_empty());
     ///```
+    #[inline]
     pub fn iter(&mut self) -> ::std::slice::Iter<(T, i64)> { 
         self.compact();
         self.updates.iter() 
@@ -145,6 +146,7 @@ impl<T:Ord> ChangeBatch<T> {
     /// }
     /// assert!(batch.is_empty());
     ///```
+    #[inline]
     pub fn drain(&mut self) -> ::std::vec::Drain<(T, i64)> {
         self.compact();
         self.clean = 0;
@@ -162,6 +164,7 @@ impl<T:Ord> ChangeBatch<T> {
     /// batch.clear();
     /// assert!(batch.is_empty());
     ///```
+    #[inline]
     pub fn clear(&mut self) { 
         self.updates.clear(); 
         self.clean = 0; 
@@ -183,6 +186,7 @@ impl<T:Ord> ChangeBatch<T> {
     /// batch.update(17, -1);
     /// assert!(batch.is_empty());
     ///```
+    #[inline]
     pub fn is_empty(&mut self) -> bool {
         if self.clean > self.updates.len() / 2 {
             false
@@ -218,6 +222,7 @@ impl<T:Ord> ChangeBatch<T> {
     /// assert!(batch1.is_empty());
     /// assert!(!batch2.is_empty());
     ///```
+    #[inline]
     pub fn drain_into(&mut self, other: &mut ChangeBatch<T>) where T: Clone {
         if other.updates.is_empty() {
             ::std::mem::swap(self, other);

--- a/src/progress/frontier.rs
+++ b/src/progress/frontier.rs
@@ -130,6 +130,12 @@ impl<T: PartialOrder+Ord+Clone+'static> MutableAntichain<T> {
         self.frontier_temp.clear();
     }
 
+    /// This method deletes the contents. Unlike `clear` it records doing so.
+    pub fn empty(&mut self) {
+        for index in 0 .. self.updates.len() { self.updates[index].1 = 0; }
+        self.dirty = self.updates.len();
+    }
+
     /// Reveals the minimal elements with positive count.
     ///
     /// #Examples

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -10,3 +10,4 @@ pub mod product;
 pub mod subgraph;
 
 pub mod reachability;
+pub mod reachability_neu;

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -360,6 +360,16 @@ impl<T:Timestamp> Tracker<T> {
         self.sources[source.index][source.port].update_dirty(time, value);
     }
 
+    /// Reference to the target mutable antichains.
+    pub fn target(&mut self, index: usize) -> &mut [MutableAntichain<T>] {
+        &mut self.targets[index]
+    }
+
+    /// Reference to the source mutable antichains.
+    pub fn source(&mut self, index: usize) -> &mut [MutableAntichain<T>] {
+        &mut self.sources[index]
+    }
+
     /// Clears the pointstamp counter.
     pub fn clear(&mut self) {
         for vec in &mut self.sources { for map in vec.iter_mut() { map.clear(); } }

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -372,6 +372,12 @@ impl<T:Timestamp> Tracker<T> {
         self.pusheds.iter_mut().all(|x| x.iter_mut().all(|y| y.is_empty()))
     } 
 
+    /// Returns true if any source or target is non-empty.
+    pub fn tracking_anything(&mut self) -> bool {
+        self.sources.iter_mut().any(|x| x.iter_mut().any(|y| !y.is_empty())) ||
+        self.targets.iter_mut().any(|x| x.iter_mut().any(|y| !y.is_empty()))            
+    }
+
     /// Allocate a new `Tracker` using the shape from `summaries`.
     pub fn allocate_from(summary: Summary<T>) -> Self {
 

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -360,6 +360,12 @@ impl<T:Timestamp> Tracker<T> {
         self.sources[source.index][source.port].update_dirty(time, value);
     }
 
+    /// Returns references to per-node state describing input and output frontiers,
+    /// and any pending updates to propagated consequences.
+    pub fn node_state(&mut self, index: usize) -> (&[MutableAntichain<T>], &[MutableAntichain<T>], &mut [ChangeBatch<T>]) {
+        (&self.targets[index], &self.sources[index], &mut self.pusheds[index][..])
+    }
+
     /// Reference to the target mutable antichains.
     pub fn target(&mut self, index: usize) -> &mut [MutableAntichain<T>] {
         &mut self.targets[index]

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -1,0 +1,395 @@
+//! Manages pointstamp reachability within a graph.
+//!
+//! Timely dataflow is concerned with understanding and communicating the potential
+//! for capabilites to reach nodes in a directed graph, by following paths through
+//! the graph (along edges and through nodes). This module contains one abstraction
+//! for managing this information.
+//!
+//! #Examples
+//!
+//! ```rust
+//! use timely::progress::frontier::Antichain;
+//! use timely::progress::nested::subgraph::{Source, Target};
+//! use timely::progress::nested::reachability_neu::{Builder, Tracker};
+//!
+//! // allocate a new empty topology builder.
+//! let mut builder = Builder::<usize>::new();
+//! 
+//! // Each node with one input connected to one output.
+//! builder.add_node(0, 1, 1, vec![vec![Antichain::from_elem(0)]]);
+//! builder.add_node(1, 1, 1, vec![vec![Antichain::from_elem(0)]]);
+//! builder.add_node(2, 1, 1, vec![vec![Antichain::from_elem(1)]]);
+//!
+//! // Connect nodes in sequence, looping around to the first from the last.
+//! builder.add_edge(Source { index: 0, port: 0}, Target { index: 1, port: 0} );
+//! builder.add_edge(Source { index: 1, port: 0}, Target { index: 2, port: 0} );
+//! builder.add_edge(Source { index: 2, port: 0}, Target { index: 0, port: 0} );
+//!
+//! // Construct a reachability tracker.
+//! let mut tracker = builder.build();
+//!
+//! // Introduce a pointstamp at the output of the first node.
+//! tracker.update_source(Source { index: 0, port: 0}, 17, 1);
+//!
+//! // Propagate changes; until this call updates are simply buffered.
+//! tracker.propagate_all();
+//!
+//! let mut results = tracker.pushed().drain().collect::<Vec<_>>();
+//! results.sort();
+//!
+//! assert_eq!(results.len(), 3);
+//! assert_eq!(results[0], ((Target { index: 0, port: 0 }, 18), 1));
+//! assert_eq!(results[1], ((Target { index: 1, port: 0 }, 17), 1));
+//! assert_eq!(results[2], ((Target { index: 2, port: 0 }, 17), 1));
+//!
+//! // Introduce a pointstamp at the output of the first node.
+//! tracker.update_source(Source { index: 0, port: 0}, 17, -1);
+//!
+//! // Propagate changes; until this call updates are simply buffered.
+//! tracker.propagate_all();
+//!
+//! let mut results = tracker.pushed().drain().collect::<Vec<_>>();
+//! results.sort();
+//!
+//! assert_eq!(results.len(), 3);
+//! assert_eq!(results[0], ((Target { index: 0, port: 0 }, 18), -1));
+//! assert_eq!(results[1], ((Target { index: 1, port: 0 }, 17), -1));
+//! assert_eq!(results[2], ((Target { index: 2, port: 0 }, 17), -1));
+//! ```
+
+use std::collections::BinaryHeap;
+
+use progress::Timestamp;
+use progress::nested::{Source, Target};
+use progress::ChangeBatch;
+
+use progress::frontier::{Antichain, MutableAntichain};
+use progress::timestamp::PathSummary;
+
+
+/// A topology builder, which can summarize reachability along paths.
+///
+/// A `Builder` takes descriptions of the nodes and edges in a graph, and compiles
+/// a static summary of the minimal actions a timestamp must endure going from any
+/// input or output port to a destination input port.
+///
+/// A graph is provides as (i) several indexed nodes, each with some number of input
+/// and output ports, and each with a summary of the internal paths connecting each
+/// input to each output, and (ii) a set of edges connecting output ports to input 
+/// ports. Edges do not adjust timestamps; only nodes do this.
+///
+/// The resulting summary describes, for each origin port in the graph and destination
+/// input port, a set of incomparable path summaries, each describing what happens to
+/// a timestamp as it moves along the path. There may be multiple summaries for each 
+/// part of origin and destination due to the fact that the actions on timestamps may
+/// not be totally ordered (e.g., "increment the timestamp" and "take the maximum of
+/// the timestamp and seven").
+///
+/// #Examples
+///
+/// ```rust
+/// use timely::progress::frontier::Antichain;
+/// use timely::progress::nested::subgraph::{Source, Target};
+/// use timely::progress::nested::reachability_neu::Builder;
+///
+/// // allocate a new empty topology builder.
+/// let mut builder = Builder::<usize>::new();
+/// 
+/// // Each node with one input connected to one output.
+/// builder.add_node(0, 1, 1, vec![vec![Antichain::from_elem(0)]]);
+/// builder.add_node(1, 1, 1, vec![vec![Antichain::from_elem(0)]]);
+/// builder.add_node(2, 1, 1, vec![vec![Antichain::from_elem(1)]]);
+///
+/// // Connect nodes in sequence, looping around to the first from the last.
+/// builder.add_edge(Source { index: 0, port: 0}, Target { index: 1, port: 0} );
+/// builder.add_edge(Source { index: 1, port: 0}, Target { index: 2, port: 0} );
+/// builder.add_edge(Source { index: 2, port: 0}, Target { index: 0, port: 0} );
+///
+/// // Summarize reachability information.
+/// let tracker = builder.build();
+/// ```
+
+#[derive(Clone, Debug)]
+pub struct Builder<T: Timestamp> {
+    /// Internal connections within hosted operators.
+    ///
+    /// Indexed by operator index, then input port, then output port. This is the
+    /// same format returned by `get_internal_summary`, as if we simply appended
+    /// all of the summaries for the hosted nodes.
+    pub nodes: Vec<Vec<Vec<Antichain<T::Summary>>>>,
+    /// Direct connections from sources to targets. 
+    ///
+    /// Edges do not affect timestamps, so we only need to know the connectivity.
+    /// Indexed by operator index then output port.
+    pub edges: Vec<Vec<Vec<Target>>>,
+    /// Numbers of inputs and outputs for each node.
+    pub shape: Vec<(usize, usize)>,
+}
+
+impl<T: Timestamp> Builder<T> {
+
+    /// Create a new empty topology builder.
+    pub fn new() -> Self {
+        Builder {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            shape: Vec::new(),
+        }
+    }
+
+    /// Add links internal to operators.
+    ///
+    /// This method overwrites any existing summary, instead of anything more sophisticated.
+    pub fn add_node(&mut self, index: usize, inputs: usize, outputs: usize, summary: Vec<Vec<Antichain<T::Summary>>>) {
+        
+        // Assert that all summaries exist.
+        debug_assert_eq!(inputs, summary.len());
+        for x in summary.iter() { debug_assert_eq!(outputs, x.len()); }
+
+        while self.nodes.len() <= index { 
+            self.nodes.push(Vec::new());
+            self.edges.push(Vec::new());
+            self.shape.push((0, 0));
+        }
+
+        self.nodes[index] = summary;
+        if self.edges[index].len() != outputs {
+            self.edges[index] = vec![Vec::new(); outputs];
+        }
+        self.shape[index] = (inputs, outputs);
+    }
+
+    /// Add links between operators.
+    ///
+    /// This method does not check that the associated nodes and ports exist. References to
+    /// missing nodes or ports are discovered in `build`.
+    pub fn add_edge(&mut self, source: Source, target: Target) {
+
+        // Assert that the edge is between existing ports.
+        debug_assert!(source.port < self.shape[source.index].1);
+        debug_assert!(target.port < self.shape[target.index].0);
+
+        self.edges[source.index][source.port].push(target);
+    }
+
+    /// Compiles the current nodes and edges into immutable path summaries.
+    ///
+    /// This method has the opportunity to perform some error checking that the path summaries
+    /// are valid, including references to undefined nodes and ports, as well as self-loops with
+    /// default summaries (a serious liveness issue).
+    pub fn build(&self) -> Tracker<T> {
+        Tracker::allocate_from(self)
+    }
+}
+
+/// An interactive tracker of propagated reachability information.
+///
+/// A `Tracker` tracks, for a fixed graph topology, the consequences of
+/// pointstamp changes at various node input and output ports. These changes may
+/// alter the potential pointstamps that could arrive at downstream input ports.
+
+#[derive(Debug)]
+pub struct Tracker<T:Timestamp> {
+
+    // TODO: All of the sizes of these allocations are static (except internal to `ChangeBatch`).
+    //       It seems we should be able to flatten most of these so that there are a few allocations
+    //       independent of the numbers of nodes and ports and such.
+    //
+    // TODO: We could also change the internal representation to be a graph of targets, using usize
+    //       identifiers for each, so that internally we needn't use multiple levels of indirection.
+    //       This may make more sense once we commit to topologically ordering the targets.
+
+    /// Each source and target has a mutable antichain to ensure that we track their discrete frontiers,
+    /// rather than their multiplicities. We separately track the frontiers resulting from propagated
+    /// frontiers, to protect them from transient negativity in inbound target updates.
+    sources: Vec<Vec<MutableAntichain<T>>>,
+    targets: Vec<Vec<MutableAntichain<T>>>,
+    pusheds: Vec<Vec<MutableAntichain<T>>>,
+
+    /// Source and target changes are buffered, which allows us to delay processing until propagation,
+    /// and so consolidate updates, but to leap directly to those frontiers that may have changed.
+    source_changes: ChangeBatch<(Source, T)>,
+    target_changes: ChangeBatch<(Target, T)>,
+
+    /// Worklist of updates to perform, ordered by increasing timestamp and target.
+    target_worklist: BinaryHeap<OrderReversed<(T, Target, i64)>>,
+
+    /// Buffer of consequent changes.
+    pushed_changes: ChangeBatch<(Target, T)>,
+
+    /// Internal connections within hosted operators.
+    ///
+    /// Indexed by operator index, then input port, then output port. This is the
+    /// same format returned by `get_internal_summary`, as if we simply appended
+    /// all of the summaries for the hosted nodes.
+    nodes: Vec<Vec<Vec<Antichain<T::Summary>>>>,
+    /// Direct connections from sources to targets. 
+    ///
+    /// Edges do not affect timestamps, so we only need to know the connectivity.
+    /// Indexed by operator index then output port.
+    edges: Vec<Vec<Vec<Target>>>,
+
+    /// Compiled reach from each target to targets one hop downstream.
+    compiled: Vec<Vec<Vec<(Target, T::Summary)>>>,
+}
+
+impl<T:Timestamp> Tracker<T> {
+
+    /// Updates the count for a time at a target.
+    #[inline]
+    pub fn update_target(&mut self, target: Target, time: T, value: i64) {
+        self.target_changes.update((target, time), value);
+    }
+    /// Updates the count for a time at a source.
+    #[inline]
+    pub fn update_source(&mut self, source: Source, time: T, value: i64) {
+        self.source_changes.update((source, time), value);
+    }
+
+    /// Allocate a new `Tracker` using the shape from `summaries`.
+    pub fn allocate_from(builder: &Builder<T>) -> Self {
+
+        let mut sources = Vec::with_capacity(builder.shape.len());
+        let mut targets = Vec::with_capacity(builder.shape.len());
+        let mut pusheds = Vec::with_capacity(builder.shape.len());
+
+        let mut compiled = Vec::with_capacity(builder.shape.len());
+
+        // Allocate buffer space for each input and input port.
+        for (node, &(inputs, outputs)) in builder.shape.iter().enumerate() {
+            sources.push(vec![MutableAntichain::new(); outputs]);
+            targets.push(vec![MutableAntichain::new(); inputs]);
+            pusheds.push(vec![MutableAntichain::new(); inputs]);
+
+            let mut compiled_node = vec![Vec::new(); inputs];
+            for input in 0 .. inputs {
+                for output in 0 .. outputs {
+                    for summary in builder.nodes[node][input][output].elements().iter() {
+                        for &target in builder.edges[node][output].iter() {
+                            compiled_node[input].push((target, summary.clone()));
+                        }
+                    }
+                }
+            }
+            compiled.push(compiled_node);
+        }
+
+        Tracker {
+            sources,
+            targets,
+            pusheds,
+            source_changes: ChangeBatch::new(),
+            target_changes: ChangeBatch::new(),
+            target_worklist: BinaryHeap::new(),
+            pushed_changes: ChangeBatch::new(),
+            nodes: builder.nodes.clone(),
+            edges: builder.edges.clone(),
+            compiled,
+        }
+    }
+
+    /// Propagates all pending updates.
+    pub fn propagate_all(&mut self) {
+
+        // Filter each target change through `self.targets`.
+        for ((target, time), diff) in self.target_changes.drain() {
+            let target_worklist = &mut self.target_worklist;
+            self.targets[target.index][target.port].update_iter_and(Some((time, diff)), |time, diff| {
+                target_worklist.push(OrderReversed::new((time.clone(), target, diff)))
+            })
+        }
+
+        // Filter each source change through `self.sources` and then along edges.
+        for ((source, time), diff) in self.source_changes.drain() {
+            let target_worklist = &mut self.target_worklist;
+            let edges = &self.edges[source.index][source.port];
+            self.sources[source.index][source.port].update_iter_and(Some((time, diff)), |time, diff| {
+                for &target in edges.iter() {
+                    target_worklist.push(OrderReversed::new((time.clone(), target, diff)))
+                }
+            })
+        }
+
+        while !self.target_worklist.is_empty() {
+
+            // This iteration we will drain all (target, time) work items.
+            let (time, target, mut diff) = self.target_worklist.pop().unwrap().element;
+
+            // Drain any other updates that might have the same time; accumulate difference.
+            while self.target_worklist.peek().map(|x| (x.element.0 == time) && (x.element.1 == target)).unwrap_or(false) {
+                diff += self.target_worklist.pop().unwrap().element.2;
+            }
+
+            // Only act if there is a net change, positive or negative.
+            if diff != 0 {
+
+                // Borrow various self fields to appease Rust.
+                let pushed_changes = &mut self.pushed_changes;
+                let target_worklist = &mut self.target_worklist;
+                let _edges = &self.edges[target.index];
+                let _nodes = &self.nodes[target.index][target.port];
+                let _compiled = &self.compiled[target.index][target.port];
+
+                // Although single-element updates may seem wasteful, they are important for termination.
+                self.pusheds[target.index][target.port].update_iter_and(Some((time, diff)), |time, diff| {
+
+                    // Identify the change in the out change list.
+                    pushed_changes.update((target, time.clone()), diff);
+
+                    // When a target has its frontier change we should communicate the change to downstream
+                    // targets as well. This means traversing the operator to its outputs.
+                    //
+                    // We have two implementations, first traversing `nodes` and `edges`, and second using
+                    // a compiled representation that flattens all these lists (but has redundant calls to
+                    // `results_in`).
+
+                    // // Version 1.
+                    // for (output, summaries) in _nodes.iter().enumerate() {
+                    //     for summary in summaries.elements().iter() {
+                    //         if let Some(new_time) = summary.results_in(time) {
+                    //             for &new_target in _edges[output].iter() {
+                    //                 target_worklist.push(OrderReversed::new((new_time.clone(), new_target, diff)));
+                    //             }
+                    //         }
+                    //     }
+                    // }
+
+                    // Version 2.
+                    for &(new_target, ref summary) in _compiled.iter() {
+                        if let Some(new_time) = summary.results_in(time) {
+                            target_worklist.push(OrderReversed::new((new_time.clone(), new_target, diff)));
+                        }
+                    }
+
+                })
+            }
+
+        }
+    }
+
+    /// A mutable reference to the pushed results of changes.
+    pub fn pushed(&mut self) -> &mut ChangeBatch<(Target, T)> {
+        &mut self.pushed_changes
+    }
+}
+
+
+#[derive(PartialEq, Eq, Debug)]
+struct OrderReversed<T> {
+    pub element: T,
+}
+
+impl<T> OrderReversed<T> {
+    fn new(element: T) -> Self { OrderReversed { element } }
+}
+
+impl<T: PartialOrd> PartialOrd for OrderReversed<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+        other.element.partial_cmp(&self.element)
+    }
+}
+impl<T: Ord> Ord for OrderReversed<T> {
+    fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+        other.element.cmp(&self.element)
+    }
+}

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -330,12 +330,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
 
         self.pointstamp_tracker = reachability::Tracker::allocate_from(pointstamp_summaries.clone());
 
-        // // Install the supplied external capabilities as child 0's internal capabilities.
-        // for input in 0..self.inputs {
-        //     let iterator = frontier[input].drain().map(|(time, diff)| (Product::new(time, Default::default()), diff));
-        //     self.children[0].internal[input].update_iter(iterator);
-        // }
-
         // Initialize all expressed capablities as pointstamps, for propagation.
         for child in self.children.iter_mut() {
             for output in 0 .. child.outputs {
@@ -346,13 +340,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
                         value,                        
                     )
                 }
-                // for time in child.internal[output].frontier().iter() {
-                //     self.pointstamp_tracker.update_source(
-                //         Source { index: child.index, port: output },
-                //         time.clone(),
-                //         1
-                //     );
-                // }
             }
         }
 


### PR DESCRIPTION
This PR merges in several changes to the structure of `subgraph.rs` which should make it easier for us to schedule or not schedule operators based on what we know about them (held capabilities, progress changes, etc). It should *not* be a functionality change; this would be a bug (or highly unintended, at least). All tests pass, but more things could shake out with exercise.

It also preps a 0.5 release, because apparently I do that in branches now.