### PR TITLE
Scheduling

### DIFF
--- a/kafkaesque/src/lib.rs
+++ b/kafkaesque/src/lib.rs
@@ -105,13 +105,12 @@ impl<T, D> EventConsumer<T, D> {
 
 impl<T: Abomonation, D: Abomonation> EventIterator<T, D> for EventConsumer<T, D> {
     fn next(&mut self) -> Option<&Event<T, D>> {
-        let buffer = &mut self.buffer;
         if let Some(result) = self.consumer.poll(0) {
             match result {
                 Ok(message) =>  {
-                    buffer.clear();
-                    buffer.extend_from_slice(message.payload().unwrap());
-                    Some(unsafe { ::abomonation::decode::<Event<T,D>>(&mut buffer[..]).unwrap().0 })
+                    self.buffer.clear();
+                    self.buffer.extend_from_slice(message.payload().unwrap());
+                    Some(unsafe { ::abomonation::decode::<Event<T,D>>(&mut self.buffer[..]).unwrap().0 })
                 },
                 Err(err) => {
                     println!("KafkaConsumer error: {:?}", err);


### PR DESCRIPTION
This PR commits to changes in the structure of scheduling operators in a `Subgraph`. 

In particular, it commits to the change that operators are simultaneously subjected to `push_external_progress` and `pull_internal_progress`, as separating these two has some cognitive and correctness implications (pep calls include the guarantee that they reflect the most recent pip results). This new structure should make it easier to reason about executing a subset of the operators in a subgraph, selectively, based on whatever conditions we like.

Some specific conditions are called out, and which in principle change the behavior of timely computations. An operator is now scheduled only if at least one of the following four things is true:

1. There are some progress updates to report to the operator, reflecting changes in its input frontiers,
2. The operator was recently active, meaning its most recent execution performed non-trivial progress work or explicitly indicate that it was still active (this is important in part because of the pep/pip contract above; even without an obvious progress change, the confirmation that this remains true even after the most recent pip call is information for the operator),
3. There are unprocessed messages for an input port *somewhere in the system*. This information is taken from the progress tracker, rather than the input queue for the operator. This is mostly due to ease; that information is immediately at hand and while maybe stale should be safe to wait on,
4. The operator holds any capabilities.

It is a simple matter to comment out this test and run all operators unconditionally, but the current belief is that if your operator needs that it should be explicitly indicating that it remains active using the pip return value. If you have a computation that is stalling, we should figure out why and determine if these rules are not sufficiently conservative, or if there is an operator that is not properly expressing its requirements.

This change passes current tests, including the multiworker barrier sync test, though this is not a rigorous exercise of the system under adverse circumstances.