### PR TITLE
CapabilityRef

### DIFF
--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -63,7 +63,7 @@ fn main() {
 
                     // receive edges, start to sort them
                     input1.for_each(|time, data| {
-                        notify.notify_at(time);
+                        notify.notify_at(time.retain());
                         edge_list.push(data.replace_with(Vec::new()));
                     });
 
@@ -71,7 +71,7 @@ fn main() {
                     input2.for_each(|time, data| {
                         node_lists.entry(time.time().clone())
                                   .or_insert_with(|| {
-                                      notify.notify_at(time.clone());
+                                      notify.notify_at(time.retain());
                                       Vec::new()
                                   })
                                   .push(data.replace_with(Vec::new()));

--- a/examples/hashjoin.rs
+++ b/examples/hashjoin.rs
@@ -83,10 +83,10 @@ fn main() {
         while sent < (vals / peers) {
 
             // Send some amount of data, no more than `batch`.
-            let to_send = std::cmp::min(batch, (vals/peers - sent));
+            let to_send = std::cmp::min(batch, vals/peers - sent);
             for _ in 0 .. to_send {
                 input1.send((rng.gen_range(0, keys), rng.gen_range(0, keys)));
-                input2.send((rng.gen_range(0, keys), rng.gen_range(0, keys)));                
+                input2.send((rng.gen_range(0, keys), rng.gen_range(0, keys)));
             }
             sent += to_send;
 

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -34,7 +34,7 @@ fn main() {
 
             // bring edges and ranks together!
             let changes = edge_stream.binary_frontier(
-                &rank_stream, 
+                &rank_stream,
                 Exchange::new(|x: &((usize, usize), i64)| (x.0).0 as u64),
                 Exchange::new(|x: &(usize, i64)| x.0 as u64),
                 "PageRank",
@@ -51,26 +51,26 @@ fn main() {
                     let mut delta = Vec::new();
 
                     let timer = ::std::time::Instant::now();
-                    
+
                     move |input1, input2, output| {
 
                         // hold on to edge changes until it is time.
                         input1.for_each(|time, data| {
-                            edge_stash.entry(time).or_insert(Vec::new()).extend(data.drain(..));
+                            edge_stash.entry(time.retain()).or_insert(Vec::new()).extend(data.drain(..));
                         });
 
                         // hold on to rank changes until it is time.
                         input2.for_each(|time, data| {
-                            rank_stash.entry(time).or_insert(Vec::new()).extend(data.drain(..));
+                            rank_stash.entry(time.retain()).or_insert(Vec::new()).extend(data.drain(..));
                         });
 
                         let frontiers = &[input1.frontier(), input2.frontier()];
 
                         for (time, edge_changes) in edge_stash.iter_mut() {
                             if frontiers.iter().all(|f| !f.less_equal(time)) {
-                                
+
                                 let mut session = output.session(time);
-            
+
                                 compact(edge_changes);
 
                                 for ((src, dst), diff) in edge_changes.drain(..) {
@@ -104,7 +104,7 @@ fn main() {
 
                         for (time, rank_changes) in rank_stash.iter_mut() {
                             if frontiers.iter().all(|f| !f.less_equal(time)) {
-                                
+
                                 let mut session = output.session(time);
 
                                 compact(rank_changes);
@@ -150,7 +150,7 @@ fn main() {
                         }
 
                         rank_stash.retain(|_key, val| !val.is_empty());
-                        
+
                     }
                 }
             );
@@ -200,7 +200,7 @@ fn compact<T: Ord>(list: &mut Vec<(T, i64)>) {
             }
         }
         list.retain(|x| x.1 != 0);
-    } 
+    }
 }
 
 // this method allocates some rank between elements of `edges`.

--- a/examples/wordcount.rs
+++ b/examples/wordcount.rs
@@ -19,7 +19,7 @@ fn main() {
         // create a new input, exchange data, and inspect its output
         worker.dataflow(|scope| {
             input.to_stream(scope)
-                 .flat_map(|(text, diff): (String, i64)| 
+                 .flat_map(|(text, diff): (String, i64)|
                     text.split_whitespace()
                         .map(move |word| (word.to_owned(), diff))
                         .collect::<Vec<_>>()
@@ -31,7 +31,7 @@ fn main() {
 
                     move |input, output| {
                         while let Some((time, data)) = input.next() {
-                            queues.entry(time)
+                            queues.entry(time.retain())
                                   .or_insert(Vec::new())
                                   .push(data.take());
                         }

--- a/src/dataflow/operators/aggregation/aggregate.rs
+++ b/src/dataflow/operators/aggregation/aggregate.rs
@@ -8,18 +8,18 @@ use dataflow::operators::generic::unary::Unary;
 use dataflow::channels::pact::Exchange;
 
 /// Generic intra-timestamp aggregation
-/// 
-/// Extension method supporting aggregation of keyed data within timestamp. 
+///
+/// Extension method supporting aggregation of keyed data within timestamp.
 /// For inter-timestamp aggregation, consider `StateMachine`.
 pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
 	/// Aggregates data of the form `(key, val)`, using user-supplied logic.
 	///
-	/// The `aggregate` method is implemented for streams of `(K, V)` data, 
-	/// and takes functions `fold`, `emit`, and `hash`; used to combine new `V` 
-	/// data with existing `D` state, to produce `R` output from `D` state, and 
+	/// The `aggregate` method is implemented for streams of `(K, V)` data,
+	/// and takes functions `fold`, `emit`, and `hash`; used to combine new `V`
+	/// data with existing `D` state, to produce `R` output from `D` state, and
 	/// to route `K` keys, respectively.
 	///
-	/// Aggregation happens within each time, and results are produced once the 
+	/// Aggregation happens within each time, and results are produced once the
 	/// time is complete.
 	///
     /// #Examples
@@ -32,8 +32,8 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
     ///		(0..10).to_stream(scope)
     ///			   .map(|x| (x % 2, x))
     ///			   .aggregate(
-    ///			   	   |_key, val, agg| { *agg += val; }, 
-    ///                |key, agg: i32| (key, agg), 
+    ///			   	   |_key, val, agg| { *agg += val; },
+    ///                |key, agg: i32| (key, agg),
     ///                |key| *key as u64
     ///            )
     ///			   .inspect(|x| assert!(*x == (0, 20) || *x == (1, 25)));
@@ -41,9 +41,9 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
     /// ```
     ///
     /// By changing the type of the aggregate value, one can accumulate into different types.
-    /// Here we accumulate the data into a `Vec<i32>` and report its length (which we could 
+    /// Here we accumulate the data into a `Vec<i32>` and report its length (which we could
     /// obviously do more efficiently; imagine we were doing a hash instead).
-    /// 	
+    ///
     /// ```
     /// use timely::dataflow::operators::{ToStream, Map, Inspect};
     /// use timely::dataflow::operators::aggregation::Aggregate;
@@ -53,33 +53,33 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
     ///		(0..10).to_stream(scope)
     ///			   .map(|x| (x % 2, x))
     ///            .aggregate::<_,Vec<i32>,_,_,_>(
-    ///                |_key, val, agg| { agg.push(val); }, 
-    ///                |key, agg| (key, agg.len()), 
+    ///                |_key, val, agg| { agg.push(val); },
+    ///                |key, agg| (key, agg.len()),
     ///                |key| *key as u64
     ///            )
     ///            .inspect(|x| assert!(*x == (0, 5) || *x == (1, 5)));
     /// });
-    /// ```	
+    /// ```
     fn aggregate<
-		R: Data, 
-		D: Default+'static, 
-		F: Fn(&K, V, &mut D)+'static, 
+		R: Data,
+		D: Default+'static,
+		F: Fn(&K, V, &mut D)+'static,
 		G: Fn(K, D)->R+'static,
 		H: Fn(&K)->u64+'static,
 	>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp: Eq;
-} 
+}
 
 impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, (K, V)> {
 
 		fn aggregate<
-			R: Data, 
-			D: Default+'static, 
-			F: Fn(&K, V, &mut D)+'static, 
+			R: Data,
+			D: Default+'static,
+			F: Fn(&K, V, &mut D)+'static,
 			G: Fn(K, D)->R+'static,
 			H: Fn(&K)->u64+'static,
 		>(&self, fold: F, emit: G, hash: H) -> Stream<S, R> where S::Timestamp: Eq {
 
-		let mut aggregates = HashMap::new(); 
+		let mut aggregates = HashMap::new();
 
 		self.unary_notify(Exchange::new(move |&(ref k, _)| hash(k)), "Aggregate", vec![], move |input, output, notificator| {
 
@@ -90,7 +90,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for 
 					let agg = agg_time.entry(key.clone()).or_insert_with(Default::default);
 					fold(&key, val, agg);
 				}
-				notificator.notify_at(time);
+				notificator.notify_at(time.retain());
 			});
 
 			// pop completed aggregates, send along whatever

--- a/src/dataflow/operators/count.rs
+++ b/src/dataflow/operators/count.rs
@@ -27,7 +27,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     ///
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(RootTimestamp::new(0), vec![45])]);
-    /// ```            
+    /// ```
     fn accumulate<A: Data, F: Fn(&mut A, &mut Content<D>)+'static>(&self, default: A, logic: F) -> Stream<G, A>;
     /// Counts the number of records observed at each time.
     ///
@@ -46,7 +46,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     ///
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(RootTimestamp::new(0), vec![10])]);
-    /// ```        
+    /// ```
     fn count(&self) -> Stream<G, usize> {
         self.accumulate(0, |sum, data| *sum += data.len())
     }
@@ -59,7 +59,7 @@ impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, D> {
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {
             input.for_each(|time, data| {
                 logic(&mut accums.entry(time.time().clone()).or_insert_with(|| default.clone()), data);
-                notificator.notify_at(time);
+                notificator.notify_at(time.retain());
             });
 
             notificator.for_each(|time,_,_| {

--- a/src/dataflow/operators/generic/binary.rs
+++ b/src/dataflow/operators/generic/binary.rs
@@ -64,11 +64,11 @@ pub trait Binary<G: Scope, D1: Data> {
     ///     stream1.binary_notify(&stream2, Pipeline, Pipeline, "example", Vec::new(), |input1, input2, output, notificator| {
     ///         input1.for_each(|time, data| {
     ///             output.session(&time).give_content(data);
-    ///             notificator.notify_at(time);
+    ///             notificator.notify_at(time.retain());
     ///         });
     ///         input2.for_each(|time, data| {
     ///             output.session(&time).give_content(data);
-    ///             notificator.notify_at(time);
+    ///             notificator.notify_at(time.retain());
     ///         });
     ///         notificator.for_each(|time,_count,_notificator| {
     ///             println!("done with time: {:?}", time.time());

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -15,8 +15,9 @@ use dataflow::channels::Content;
 use timely_communication::{Push, Pull};
 use logging::Logger;
 
-use dataflow::operators::{Capability, CapabilityTrait};
-use dataflow::operators::capability::mint as mint_capability;
+use dataflow::operators::CapabilityRef;
+use dataflow::operators::capability::mint_ref as mint_capability_ref;
+use dataflow::operators::capability::CapabilityTrait;
 
 /// Handle to an operator's input stream.
 pub struct InputHandle<T: Timestamp, D, P: Pull<(T, Content<D>)>> {
@@ -39,10 +40,10 @@ impl<'a, T: Timestamp, D, P: Pull<(T, Content<D>)>> InputHandle<T, D, P> {
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
     /// Returns `None` when there's no more data available.
     #[inline(always)]
-    pub fn next(&mut self) -> Option<(Capability<T>, &mut Content<D>)> {
+    pub fn next(&mut self) -> Option<(CapabilityRef<T>, &mut Content<D>)> {
         let internal = &mut self.internal;
         self.pull_counter.next().map(|(time, content)| {
-            (mint_capability(time.clone(), internal.clone()), content)
+            (mint_capability_ref(time, internal.clone()), content)
         })
     }
 
@@ -65,7 +66,7 @@ impl<'a, T: Timestamp, D, P: Pull<(T, Content<D>)>> InputHandle<T, D, P> {
     /// });
     /// ```
     #[inline]
-    pub fn for_each<F: FnMut(Capability<T>, &mut Content<D>)>(&mut self, mut logic: F) {
+    pub fn for_each<F: FnMut(CapabilityRef<T>, &mut Content<D>)>(&mut self, mut logic: F) {
         let logging = self.logging.clone();
         while let Some((cap, data)) = self.next() {
             logging.when_enabled(|l| l.log(::logging::TimelyEvent::GuardedMessage(
@@ -83,7 +84,7 @@ impl<'a, T: Timestamp, D, P: Pull<(T, Content<D>)>+'a> FrontieredInputHandle<'a,
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
     /// Returns `None` when there's no more data available.
     #[inline(always)]
-    pub fn next(&mut self) -> Option<(Capability<T>, &mut Content<D>)> {
+    pub fn next(&mut self) -> Option<(CapabilityRef<T>, &mut Content<D>)> {
         self.handle.next()
     }
 
@@ -106,7 +107,7 @@ impl<'a, T: Timestamp, D, P: Pull<(T, Content<D>)>+'a> FrontieredInputHandle<'a,
     /// });
     /// ```
     #[inline]
-    pub fn for_each<F: FnMut(Capability<T>, &mut Content<D>)>(&mut self, logic: F) {
+    pub fn for_each<F: FnMut(CapabilityRef<T>, &mut Content<D>)>(&mut self, logic: F) {
         self.handle.for_each(logic)
     }
 

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -1,6 +1,6 @@
 //! Handles to an operator's input and output streams.
 //!
-//! These handles are used by the generic operator interfaces to allow user closures to interact as 
+//! These handles are used by the generic operator interfaces to allow user closures to interact as
 //! the operator would with its input and output streams.
 
 use std::rc::Rc;
@@ -15,7 +15,7 @@ use dataflow::channels::Content;
 use timely_communication::{Push, Pull};
 use logging::Logger;
 
-use dataflow::operators::Capability;
+use dataflow::operators::{Capability, CapabilityTrait};
 use dataflow::operators::capability::mint as mint_capability;
 
 /// Handle to an operator's input stream.
@@ -195,8 +195,8 @@ impl<'a, T: Timestamp, D, P: Push<(T, Content<D>)>> OutputHandle<'a, T, D, P> {
     ///            });
     /// });
     /// ```
-    pub fn session<'b>(&'b mut self, cap: &'b Capability<T>) -> Session<'b, T, D, PushCounter<T, D, P>> where 'a: 'b {
-        self.push_buffer.session(cap)
+    pub fn session<'b, C: CapabilityTrait<T>>(&'b mut self, cap: &'b C) -> Session<'b, T, D, PushCounter<T, D, P>> where 'a: 'b {
+        self.push_buffer.session(cap.time())
     }
 }
 

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -202,11 +202,11 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///             move |input1, input2, output| {
 ///                 while let Some((time, data)) = input1.next() {
 ///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
-///                     notificator.notify_at(time);
+///                     notificator.notify_at(time.retain());
 ///                 }
 ///                 while let Some((time, data)) = input2.next() {
 ///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
-///                     notificator.notify_at(time);
+///                     notificator.notify_at(time.retain());
 ///                 }
 ///                 notificator.for_each(&[input1.frontier(), input2.frontier()], |time, _| {
 ///                     if let Some(mut vec) = stash.remove(time.time()) {
@@ -335,7 +335,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///
     /// In the interest of efficiency, this method may yield capabilities in decreasing order, in certain
     /// circumstances. If you want to iterate through capabilities with an in-order guarantee, either (i)
-    /// use `for_each` 
+    /// use `for_each`
     #[inline]
     pub fn next<'a>(&mut self, frontiers: &'a [&'a MutableAntichain<T>]) -> Option<Capability<T>> {
         if self.available.is_empty() {

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -56,7 +56,7 @@ pub trait Operator<G: Scope, D1: Data> {
     where
         D2: Data,
         B: FnOnce(Capability<G::Timestamp>) -> L,
-        L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>, 
+        L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
@@ -91,7 +91,7 @@ pub trait Operator<G: Scope, D1: Data> {
     where
         D2: Data,
         B: FnOnce(Capability<G::Timestamp>) -> L,
-        L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>, 
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
@@ -116,11 +116,11 @@ pub trait Operator<G: Scope, D1: Data> {
     ///            move |input1, input2, output| {
     ///                while let Some((time, data)) = input1.next() {
     ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
-    ///                    notificator.notify_at(time);
+    ///                    notificator.notify_at(time.retain());
     ///                }
     ///                while let Some((time, data)) = input2.next() {
     ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
-    ///                    notificator.notify_at(time);
+    ///                    notificator.notify_at(time.retain());
     ///                }
     ///                notificator.for_each(&[input1.frontier(), input2.frontier()], |time, _not| {
     ///                    if let Some(mut vec) = stash.remove(time.time()) {
@@ -188,8 +188,8 @@ pub trait Operator<G: Scope, D1: Data> {
         D2: Data,
         D3: Data,
         B: FnOnce(Capability<G::Timestamp>) -> L,
-        L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>, 
-                 &mut InputHandle<G::Timestamp, D2, P2::Puller>, 
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
+                 &mut InputHandle<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;
@@ -218,8 +218,8 @@ pub trait Operator<G: Scope, D1: Data> {
     ///         });
     /// });
     /// ```
-    fn sink<L, P>(&self, pact: P, name: &str, logic: L) 
-    where 
+    fn sink<L, P>(&self, pact: P, name: &str, logic: L)
+    where
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 }
@@ -230,7 +230,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
     where
         D2: Data,
         B: FnOnce(Capability<G::Timestamp>) -> L,
-        L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>, 
+        L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
@@ -244,7 +244,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             move |frontiers| {
                 let mut input_handle = new_frontier_input_handle(&mut input, &frontiers[0]);
                 let mut output_handle = output.activate();
-                logic(&mut input_handle, &mut output_handle);        
+                logic(&mut input_handle, &mut output_handle);
             }
         });
 
@@ -255,7 +255,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
     where
         D2: Data,
         B: FnOnce(Capability<G::Timestamp>) -> L,
-        L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>, 
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
@@ -269,7 +269,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             let mut logic = constructor(capability);
             move |_frontiers| {
                 let mut output_handle = output.activate();
-                logic(&mut input, &mut output_handle);        
+                logic(&mut input, &mut output_handle);
             }
         });
 
@@ -299,7 +299,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
                 let mut input1_handle = new_frontier_input_handle(&mut input1, &frontiers[0]);
                 let mut input2_handle = new_frontier_input_handle(&mut input2, &frontiers[1]);
                 let mut output_handle = output.activate();
-                logic(&mut input1_handle, &mut input2_handle, &mut output_handle);        
+                logic(&mut input1_handle, &mut input2_handle, &mut output_handle);
             }
         });
 
@@ -311,8 +311,8 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         D2: Data,
         D3: Data,
         B: FnOnce(Capability<G::Timestamp>) -> L,
-        L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>, 
-                 &mut InputHandle<G::Timestamp, D2, P2::Puller>, 
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
+                 &mut InputHandle<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2> {
@@ -328,15 +328,15 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
             let mut logic = constructor(capability);
             move |_frontiers| {
                 let mut output_handle = output.activate();
-                logic(&mut input1, &mut input2, &mut output_handle);        
+                logic(&mut input1, &mut input2, &mut output_handle);
             }
         });
 
         stream
     }
 
-    fn sink<L, P>(&self, pact: P, name: &str, mut logic: L) 
-    where 
+    fn sink<L, P>(&self, pact: P, name: &str, mut logic: L)
+    where
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
@@ -346,7 +346,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         builder.build(|_capability| {
             move |frontiers| {
                 let mut input_handle = new_frontier_input_handle(&mut input, &frontiers[0]);
-                logic(&mut input_handle);        
+                logic(&mut input_handle);
             }
         });
     }

--- a/src/dataflow/operators/generic/unary.rs
+++ b/src/dataflow/operators/generic/unary.rs
@@ -54,7 +54,7 @@ pub trait Unary<G: Scope, D1: Data> {
     ///            .unary_notify(Pipeline, "example", Vec::new(), |input, output, notificator| {
     ///                input.for_each(|time, data| {
     ///                    output.session(&time).give_content(data);
-    ///                    notificator.notify_at(time);
+    ///                    notificator.notify_at(time.retain());
     ///                });
     ///                notificator.for_each(|time,_,_| {
     ///                    println!("done with time: {:?}", time.time());

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -56,3 +56,4 @@ pub mod count;
 // keep "mint" module-private
 mod capability;
 pub use self::capability::{Capability, CapabilitySet};
+use self::capability::CapabilityTrait;

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -55,5 +55,4 @@ pub mod count;
 
 // keep "mint" module-private
 mod capability;
-pub use self::capability::{Capability, CapabilitySet};
-use self::capability::CapabilityTrait;
+pub use self::capability::{Capability, CapabilityRef, CapabilitySet};

--- a/src/dataflow/operators/reclock.rs
+++ b/src/dataflow/operators/reclock.rs
@@ -11,9 +11,9 @@ pub trait Reclock<S: Scope, D: Data> {
     /// Delays records until an input is observed on the `clock` input.
     ///
     /// The source stream is buffered until a record is seen on the clock input,
-    /// at which point a notification is requested and all data with time less 
-    /// or equal to the clock time are sent. This method does not ensure that all 
-    /// workers receive the same clock records, which can be accomplished with 
+    /// at which point a notification is requested and all data with time less
+    /// or equal to the clock time are sent. This method does not ensure that all
+    /// workers receive the same clock records, which can be accomplished with
     /// `broadcast`.
     ///
     /// #Examples
@@ -24,11 +24,11 @@ pub trait Reclock<S: Scope, D: Data> {
     /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// let captured = timely::example(|scope| {
-    /// 
+    ///
     ///     // produce data 0..10 at times 0..10.
     ///     let data = (0..10).to_stream(scope)
     ///                       .delay(|x,t| RootTimestamp::new(*x));
-    /// 
+    ///
     ///     // product clock ticks at three times.
     ///     let clock = vec![3, 5, 8].into_iter()
     ///                              .to_stream(scope)
@@ -45,7 +45,7 @@ pub trait Reclock<S: Scope, D: Data> {
     /// assert_eq!(extracted[0], (RootTimestamp::new(3), vec![0,1,2,3]));
     /// assert_eq!(extracted[1], (RootTimestamp::new(5), vec![4,5]));
     /// assert_eq!(extracted[2], (RootTimestamp::new(8), vec![6,7,8]));
-    /// ```        
+    /// ```
     fn reclock(&self, clock: &Stream<S, ()>) -> Stream<S, D>;
 }
 
@@ -63,7 +63,7 @@ impl<S: Scope, D: Data> Reclock<S, D> for Stream<S, D> {
 
             // request notification at time, to flush stash.
             input2.for_each(|time, _data| {
-                notificator.notify_at(time);
+                notificator.notify_at(time.retain());
             });
 
             // each time with complete stash can be flushed.


### PR DESCRIPTION
This PR broadens the `Capability<T>` type to two instances: the original and a `CapabilityRef<'cap, T>` type which *i.* wraps a `&'cap T` and *ii.* does not increment the underlying capability counter on construction nor decrement it on drop.

The present code (pre-PR) instantiates capabilities each time one is needed by the user, which involves pushing additions and subtractions onto a change buffer, none of which are needed if the user doesn't intend to retain the capability outside the scope of the borrow. This change should ease that burden (and the cloning of the underlying `T`) as well as require a clearer statement of intent from the user that they want to retain the capability: a `CapabilityRef` provides a `retain(self)` method that converts into an owned `Capability`.

This is massively breaking, but with fairly simple fixes (it seems). Everywhere that one previously stashed a presented capability one should first call `.retain()`. Everywhere that the capability was previously used to create sessions should be unchanged (the `session` method is generic with respect to a new private trait that both capabilities and references to them implement).

@utaal 
