### PR TITLE
bytes checkin

### DIFF
--- a/bytes/.gitignore
+++ b/bytes/.gitignore
@@ -1,0 +1,3 @@
+/target
+/.vscode
+Cargo.lock

--- a/bytes/Cargo.toml
+++ b/bytes/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "bytes"
+version = "0.1.0"
+authors = ["Frank McSherry <fmcsherry@me.com>"]
+
+[dependencies]

--- a/bytes/src/lib.rs
+++ b/bytes/src/lib.rs
@@ -1,0 +1,204 @@
+//! A simplified implementation of the `bytes` crate, with different features, less safety.
+//!
+//! #Examples
+//!
+//! ```
+//! use bytes::rc::Bytes;
+//!
+//! let bytes = vec![0u8; 1024];
+//! let mut shared1 = Bytes::from(bytes);
+//! let mut shared2 = shared1.extract_to(100);
+//! let mut shared3 = shared1.extract_to(100);
+//! let mut shared4 = shared2.extract_to(60);
+//!
+//! assert_eq!(shared1.len(), 824);
+//! assert_eq!(shared2.len(), 40);
+//! assert_eq!(shared3.len(), 100);
+//! assert_eq!(shared4.len(), 60);
+//!
+//! for byte in shared1.iter_mut() { *byte = 1u8; }
+//! for byte in shared2.iter_mut() { *byte = 2u8; }
+//! for byte in shared3.iter_mut() { *byte = 3u8; }
+//! for byte in shared4.iter_mut() { *byte = 4u8; }
+//!
+//! drop(shared1);
+//! drop(shared2);
+//! drop(shared3);
+//!
+//! if let Ok(bytes) = shared4.try_recover() {
+//!     assert_eq!(bytes[200..1024].to_vec(), [1u8;824].to_vec());
+//!     assert_eq!(bytes[60..100].to_vec(),   [2u8;40].to_vec());
+//!     assert_eq!(bytes[100..200].to_vec(),  [3u8;100].to_vec());
+//!     assert_eq!(bytes[0..60].to_vec(),     [4u8;60].to_vec());
+//! }
+//! else {
+//!     panic!("unrecoverable!");
+//! }
+//! ```
+#![forbid(missing_docs)]
+
+/// An `Rc`-backed mutable byte slice backed by a common allocation.
+pub mod rc {
+
+    use std::ops::{Deref, DerefMut};
+    use std::rc::Rc;
+
+    /// A thread-local byte buffer backed by a shared allocation.
+    pub struct Bytes<B: DerefMut<Target=[u8]>> {
+        /// Pointer to the start of this slice (not the allocation).
+        ptr: *mut u8,
+        /// Length of this slice.
+        len: usize,
+        /// Shared access to underlying resources.
+        ///
+        /// Importantly, this is unavailable for as long as the struct exists, which may
+        /// prevent shared access to ptr[0 .. len]. I'm not sure I understand Rust's rules
+        /// enough to make a strong statement about this.
+        sequestered: Rc<B>,
+    }
+
+    impl<B: DerefMut<Target=[u8]>> Bytes<B> {
+
+        /// Create a new instance from a byte allocation.
+        pub fn from(mut bytes: B) -> Bytes<B> {
+            Bytes {
+                ptr: bytes.as_mut_ptr(),
+                len: bytes.len(),
+                sequestered: Rc::new(bytes),
+            }
+        }
+
+        /// Extracts [0, index) into a new `Bytes` which is returned, updating `self`.
+        ///
+        /// #Safety
+        ///
+        /// This method uses an `unsafe` region to advance the pointer by `index`. It first
+        /// tests `index` against `self.len`, which should ensure that the offset is in-bounds.
+        pub fn extract_to(&mut self, index: usize) -> Bytes<B> {
+
+            assert!(index <= self.len);
+
+            let result = Bytes {
+                ptr: self.ptr,
+                len: index,
+                sequestered: self.sequestered.clone(),
+            };
+
+            unsafe { self.ptr = self.ptr.offset(index as isize); }
+            self.len -= index;
+
+            result
+        }
+
+        /// Recover the underlying storage.
+        ///
+        /// This method either results in the underlying storage if it is uniquely held, or the
+        /// input `Bytes` if it is not uniquely held.
+        pub fn try_recover(self) -> Result<B, Bytes<B>> {
+            match Rc::try_unwrap(self.sequestered) {
+                Ok(bytes) => Ok(bytes),
+                Err(rc) => Err(Bytes {
+                    ptr: self.ptr,
+                    len: self.len,
+                    sequestered: rc,
+                }),
+            }
+        }
+    }
+
+    impl<B: DerefMut<Target=[u8]>+Clone> Deref for Bytes<B> {
+        type Target = [u8];
+        fn deref(&self) -> &[u8] {
+            unsafe { ::std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
+
+    impl<B: DerefMut<Target=[u8]>+Clone> DerefMut for Bytes<B> {
+        fn deref_mut(&mut self) -> &mut [u8] {
+            unsafe { ::std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        }
+    }
+}
+
+/// An `Arc`-backed mutable byte slice backed by a common allocation.
+pub mod arc {
+
+    use std::ops::{Deref, DerefMut};
+    use std::sync::Arc;
+
+    /// A thread-local byte buffer backed by a shared allocation.
+    pub struct Bytes<B: DerefMut<Target=[u8]>> {
+        /// Pointer to the start of this slice (not the allocation).
+        ptr: *mut u8,
+        /// Length of this slice.
+        len: usize,
+        /// Shared access to underlying resources.
+        ///
+        /// Importantly, this is unavailable for as long as the struct exists, which may
+        /// prevent shared access to ptr[0 .. len]. I'm not sure I understand Rust's rules
+        /// enough to make a strong statement about this.
+        sequestered: Arc<B>,
+    }
+
+    impl<B: DerefMut<Target=[u8]>> Bytes<B> {
+
+        /// Create a new instance from a byte allocation.
+        pub fn from(mut bytes: B) -> Bytes<B> {
+            Bytes {
+                ptr: bytes.as_mut_ptr(),
+                len: bytes.len(),
+                sequestered: Arc::new(bytes),
+            }
+        }
+
+        /// Extracts [0, index) into a new `Bytes` which is returned, updating `self`.
+        ///
+        /// #Safety
+        ///
+        /// This method uses an `unsafe` region to advance the pointer by `index`. It first
+        /// tests `index` against `self.len`, which should ensure that the offset is in-bounds.
+        pub fn extract_to(&mut self, index: usize) -> Bytes<B> {
+
+            assert!(index <= self.len);
+
+            let result = Bytes {
+                ptr: self.ptr,
+                len: index,
+                sequestered: self.sequestered.clone(),
+            };
+
+            unsafe { self.ptr = self.ptr.offset(index as isize); }
+            self.len -= index;
+
+            result
+        }
+
+        /// Recover the underlying storage.
+        ///
+        /// This method either results in the underlying storage if it is uniquely held, or the
+        /// input `Bytes` if it is not uniquely held.
+        pub fn try_recover(self) -> Result<B, Bytes<B>> {
+            match Arc::try_unwrap(self.sequestered) {
+                Ok(bytes) => Ok(bytes),
+                Err(arc) => Err(Bytes {
+                    ptr: self.ptr,
+                    len: self.len,
+                    sequestered: arc,
+                }),
+            }
+        }
+    }
+
+    impl<B: DerefMut<Target=[u8]>+Clone> Deref for Bytes<B> {
+        type Target = [u8];
+        fn deref(&self) -> &[u8] {
+            unsafe { ::std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
+
+    impl<B: DerefMut<Target=[u8]>+Clone> DerefMut for Bytes<B> {
+        fn deref_mut(&mut self) -> &mut [u8] {
+            unsafe { ::std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        }
+    }
+}

--- a/bytes/src/lib.rs
+++ b/bytes/src/lib.rs
@@ -60,11 +60,14 @@ pub mod rc {
     impl<B: DerefMut<Target=[u8]>> Bytes<B> {
 
         /// Create a new instance from a byte allocation.
-        pub fn from(mut bytes: B) -> Bytes<B> {
+        pub fn from(bytes: B) -> Bytes<B> {
+
+            let mut rc = Rc::new(bytes);
+
             Bytes {
-                ptr: bytes.as_mut_ptr(),
-                len: bytes.len(),
-                sequestered: Rc::new(bytes),
+                ptr: Rc::get_mut(&mut rc).unwrap().as_mut_ptr(),
+                len: rc.len(),
+                sequestered: rc,
             }
         }
 
@@ -126,7 +129,7 @@ pub mod arc {
     use std::ops::{Deref, DerefMut};
     use std::sync::Arc;
 
-    /// A thread-local byte buffer backed by a shared allocation.
+    /// A thread-safe byte buffer backed by a shared allocation.
     pub struct Bytes<B: DerefMut<Target=[u8]>> {
         /// Pointer to the start of this slice (not the allocation).
         ptr: *mut u8,
@@ -143,11 +146,14 @@ pub mod arc {
     impl<B: DerefMut<Target=[u8]>> Bytes<B> {
 
         /// Create a new instance from a byte allocation.
-        pub fn from(mut bytes: B) -> Bytes<B> {
+        pub fn from(bytes: B) -> Bytes<B> {
+
+            let mut arc = Arc::new(bytes);
+
             Bytes {
-                ptr: bytes.as_mut_ptr(),
-                len: bytes.len(),
-                sequestered: Arc::new(bytes),
+                ptr: Arc::get_mut(&mut arc).unwrap().as_mut_ptr(),
+                len: arc.len(),
+                sequestered: arc,
             }
         }
 

--- a/bytes/src/lib.rs
+++ b/bytes/src/lib.rs
@@ -109,14 +109,14 @@ pub mod rc {
         }
     }
 
-    impl<B: DerefMut<Target=[u8]>+Clone> Deref for Bytes<B> {
+    impl<B: DerefMut<Target=[u8]>> Deref for Bytes<B> {
         type Target = [u8];
         fn deref(&self) -> &[u8] {
             unsafe { ::std::slice::from_raw_parts(self.ptr, self.len) }
         }
     }
 
-    impl<B: DerefMut<Target=[u8]>+Clone> DerefMut for Bytes<B> {
+    impl<B: DerefMut<Target=[u8]>> DerefMut for Bytes<B> {
         fn deref_mut(&mut self) -> &mut [u8] {
             unsafe { ::std::slice::from_raw_parts_mut(self.ptr, self.len) }
         }
@@ -195,14 +195,14 @@ pub mod arc {
         }
     }
 
-    impl<B: DerefMut<Target=[u8]>+Clone> Deref for Bytes<B> {
+    impl<B: DerefMut<Target=[u8]>> Deref for Bytes<B> {
         type Target = [u8];
         fn deref(&self) -> &[u8] {
             unsafe { ::std::slice::from_raw_parts(self.ptr, self.len) }
         }
     }
 
-    impl<B: DerefMut<Target=[u8]>+Clone> DerefMut for Bytes<B> {
+    impl<B: DerefMut<Target=[u8]>> DerefMut for Bytes<B> {
         fn deref_mut(&mut self) -> &mut [u8] {
             unsafe { ::std::slice::from_raw_parts_mut(self.ptr, self.len) }
         }


### PR DESCRIPTION
This PR, not to be merged without some consideration, adds a new helper crate `bytes` meant to resemble the [crates.io bytes crate](https://crates.io/crates/bytes), but with substantially less complexity, at least one additional feature (recovering resources) and perhaps a great deal less safety (totally unclear to me).

There are two modules, `rc` and `arc`, which sequester a byte allocation behind an `Rc` or `Arc`, respectively. The type returns access to the underlying allocation only when it is able to destructure the reference using `try_unwrap`, which intends to ensure that there are no outstanding instances referencing the allocation (other than the one being consumed).

The intended benefit here is that we can slice up some bytes like `split_at_mut` and hand out independent mutable regions as long as they are disjoint, which the interface means to ensure.

I think this PR will sit here for a while until I figure out how one increases the confidence in unsafe code, other than pointing Rust people at it and seeing whether they nod or sigh.