### PR TITLE
Implement AntichainRef type

### DIFF
--- a/src/dataflow/operators/aggregation/state_machine.rs
+++ b/src/dataflow/operators/aggregation/state_machine.rs
@@ -3,7 +3,6 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use ::{Data, ExchangeData};
-use order::PartialOrder;
 use dataflow::{Stream, Scope};
 use dataflow::operators::generic::unary::Unary;
 use dataflow::channels::pact::Exchange;
@@ -72,7 +71,7 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> f
             // stash each input and request a notification when ready
             input.for_each(|time, data| {
                 // stash if not time yet
-                if notificator.frontier(0).iter().any(|x| x.less_than(time.time())) {
+                if notificator.frontier(0).less_than(time.time()) {
                     pending.entry(time.time().clone()).or_insert_with(Vec::new).extend(data.drain(..));
                     notificator.notify_at(time.retain());
                 }

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -1,4 +1,4 @@
-use progress::frontier::MutableAntichain;
+use progress::frontier::{AntichainRef, MutableAntichain};
 use progress::Timestamp;
 use dataflow::operators::Capability;
 use logging::Logger;
@@ -39,7 +39,7 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     }
 
     /// Reveals the elements in the frontier of the indicated input.
-    pub fn frontier(&self, input: usize) -> &[T] {
+    pub fn frontier(&self, input: usize) -> AntichainRef<T> {
         self.frontiers[input].frontier()
     }
 

--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use progress::Timestamp;
-use progress::frontier::MutableAntichain;
+use progress::frontier::{AntichainRef, MutableAntichain};
 use dataflow::channels::pushers::Counter as PushCounter;
 use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use dataflow::channels::pact::Pipeline;
@@ -156,7 +156,7 @@ impl<T: Timestamp> Handle<T> {
     /// let frontier = handle.with_frontier(|frontier| frontier.to_vec());
     /// ```
     #[inline]
-    pub fn with_frontier<R, F: FnMut(&[T])->R>(&self, mut function: F) -> R {
+    pub fn with_frontier<R, F: FnMut(AntichainRef<T>)->R>(&self, mut function: F) -> R {
         function(self.frontier.borrow().frontier())
     }
 }


### PR DESCRIPTION
In this PR, I'm implementing the type `AntichainRef` wrapping a slice of timestamps that are elements of an antichain, i.e. mutually incomparable elements. It is a convenience wrapper to provide functions such as `less_than`, `less_equal` to aid programmers using frontier semantics in operators.

Signed-off-by: Moritz Hoffmann <moritz.hoffmann@inf.ethz.ch>