### PR TITLE
comment out some lines

### DIFF
--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -305,14 +305,14 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         // We must first translate `summaries` to summaries in the subgraph's timestamp type.
         // Each of these summaries correspond to dropping the inner timestamp coordinate and replacing
         // it with the default value, and applying the summary to the outer coordinate.
-        let mut new_summary = vec![vec![Antichain::new(); self.inputs]; self.outputs];
-        for output in 0..self.outputs {
-            for input in 0..self.inputs {
-                for summary in summaries[output][input].elements() {
-                    new_summary[output][input].insert(Outer(summary.clone(), Default::default()));
-                }
-            }
-        }
+        // let mut new_summary = vec![vec![Antichain::new(); self.inputs]; self.outputs];
+        // for output in 0..self.outputs {
+        //     for input in 0..self.inputs {
+        //         for summary in summaries[output][input].elements() {
+        //             new_summary[output][input].insert(Outer(summary.clone(), Default::default()));
+        //         }
+        //     }
+        // }
 
         // The element of `frontier` form the initial capabilities of child zero, our proxy for the outside world.
         let mut new_capabilities = vec![ChangeBatch::new(); self.inputs];
@@ -326,7 +326,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Operate<TOuter> for Subgraph<TOuter, 
         // Specifically, and crucially, we remove summaries from the outputs of child zero to the inputs of child
         // zero. This prevents the subgraph from reporting the external world's capabilities back as capabilities
         // held by the subgraph. We also remove summaries to nodes that do not require progress information.
-        self.pointstamp_builder.add_node(0, self.outputs, self.inputs, new_summary);
+        // self.pointstamp_builder.add_node(0, self.outputs, self.inputs, new_summary);
         let mut pointstamp_summaries = self.pointstamp_builder.summarize();
         for summaries in pointstamp_summaries.target_target[0].iter_mut() { summaries.retain(|&(t, _)| t.index > 0); }
         for summaries in pointstamp_summaries.source_target[0].iter_mut() { summaries.retain(|&(t, _)| t.index > 0); }


### PR DESCRIPTION
This PR fundamentally changes how progress tracking works, by commenting out a few lines.

Note: I am not sure this is correct, and if it is not correct then it is not the right direction to go. It is more of an experiment to fix another bug, but by walking back what I always assumed was a crucial correctness property.

Progress tracking involves a relationship between parent scopes and nested child scopes. The children report on changes to the capabilities they contain, and the parent reports on changes to the capabilities in the world around them. That is the rough gist, but there were some specifics that now seem over-complicated.

1. Children report and maintain internal capabilities along strictly internal paths, and *completely ignore external paths*.

2. Parents report and maintain all capabilities along all paths, to each child.

This part in italics is new. Children used to also maintain external paths, provided by the parent scope, which they could use to reason about the possible flow of capabilities along paths at least partially external to their scope. This seems to be redundant, if we agree that any capability that exits the child scope will be reflected back to its inputs by the parent scope. These reflected capabilities can then transit only internal paths, and do not require external path summaries to track correctly (I *think*).

I came up short trying to reconstruct why external paths were necessary, or thought to be necessary. The best I could think of was that back in the day it was hoped that parent scopes might only present each child with the capabilities of others not including them, at which point the children would be required to reason about their capabilities along all edges in the dataflow graph. That hope, that parents might give more smart information to children, never manifested and seems hard (to do efficiently).

So, this very simple PR is to test out "children just report progress changes along strictly internal edges", and to see if we can surface any of the issues, while we wait for me to try and write down a proof or something. All timely and differential tests pass, so nothing is obviously problematic at the moment.