### PR TITLE
Re-export timely_communication::Allocate as timely::Allocate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ extern crate time;
 extern crate byteorder;
 
 pub use execute::{execute, execute_logging, execute_from_args, execute_from_args_logging, example};
-pub use timely_communication::{Push, Pull, Configuration};
+pub use timely_communication::{Allocate, Push, Pull, Configuration};
 pub use order::PartialOrder;
 
 pub mod progress;


### PR DESCRIPTION
Re-export timely communication's `Allocate` trait as `timely::Allocate` because it is part of the `ParallelizationContract`'s public API.

Signed-off-by: Moritz Hoffmann <moritz.hoffmann@inf.ethz.ch>