### PR TITLE
dont detach send thread

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timely_communication"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "Communication layer for timely dataflow"

--- a/communication/src/networking.rs
+++ b/communication/src/networking.rs
@@ -161,7 +161,8 @@ impl<W: Write> BinarySender<W> {
     fn send_loop(&mut self) {
         let mut stash = Vec::new();
 
-        // block until data to recv
+        // This blocks until there is data to receive, and should return an `Err(_)` once all matching `Sender` instances
+        // have been dropped. This should allow the method to return, and the send thread to cleanly exit on shutdown.
         while let Ok((header, buffer)) = self.sources.recv() {
 
             stash.push((header, buffer));
@@ -233,10 +234,10 @@ pub fn initialize_networking(
     let start_task = thread::spawn(move || start_connections(hosts1, my_index, noisy));
     let await_task = thread::spawn(move || await_connections(hosts2, my_index, noisy));
 
-    let mut results = try!(start_task.join().unwrap());
+    let mut results = start_task.join().unwrap()?;
 
     results.push(None);
-    let to_extend = try!(await_task.join().unwrap());
+    let to_extend = await_task.join().unwrap()?;
     results.extend(to_extend.into_iter());
 
     if noisy { println!("worker {}:\tinitialization complete", my_index) }
@@ -251,14 +252,14 @@ pub fn initialize_networking(
             let (reader_channels_s, reader_channels_r) = channel();
             let (sender_channels_s, sender_channels_r) = channel();
 
-            readers.push(reader_channels_s);    //
-            senders.push(sender_channels_s);    //
-
+            readers.push(reader_channels_s);
+            senders.push(sender_channels_s);
 
             {
                 let log_sender = log_sender.clone();
-                let stream = stream.try_clone().unwrap();
+                let stream = stream.try_clone()?;
                 // start senders and receivers associated with this stream
+                let join_guard =
                 thread::Builder::new().name(format!("send thread {}", index))
                                       .spawn(move || {
                                           let log_sender = log_sender(::logging::CommsSetup {
@@ -270,12 +271,18 @@ pub fn initialize_networking(
                                                                              sender_channels_r,
                                                                              log_sender);
                                           sender.send_loop()
-                                      }).unwrap();
+                                      })?;
+
+                // Forget the guard, so that the send thread is not detached from the main thread.
+                // This ensures that main thread awaits the completion of the send thread, and all
+                // of its transmissions, before exiting and potentially stranding other workers.
+                ::std::mem::forget(join_guard);
             }
 
             {
                 let log_sender = log_sender.clone();
-                let stream = stream.try_clone().unwrap();
+                let stream = stream.try_clone()?;
+                let _join_guard =
                 thread::Builder::new().name(format!("recv thread {}", index))
                                       .spawn(move || {
                                           let log_sender = log_sender(::logging::CommsSetup {
@@ -287,7 +294,13 @@ pub fn initialize_networking(
                                                                                reader_channels_r,
                                                                                log_sender);
                                           recver.recv_loop()
-                                      }).unwrap();
+                                      })?;
+
+                // We do not mem::forget the join_guard here, because we deem there to be no harm
+                // in closing the process and abandoning the receiver thread. All worker threads
+                // will have exited, and we don't expect that continuing to read has a benefit.
+                // We could introduce a "shutdown" message into the "protocol" which would confirm
+                // a clear conclusion to the interaction.
             }
 
         }


### PR DESCRIPTION
This PR avoids detaching the communication threads executing `send_loop`, which should ensure that on clean shutdown these threads are able to drain all outbound communication. This is intended to fix defects observed by @utaal, @jonhoo, @ms705.

@utaal observed hangs at shutdown, which lines up with the issue that the send thread perhaps closed before it could transmit the last of its progress messages, say, leaving other processes stalled waiting for anything. In principle they could see the broken socket and react, but they currently ignore this because .. right.

@jonhoo and @ms705 observed panics in the `send_loop` trying to send at a closed socket. I'm less clear about how this happened, as no process should cleanly exit while another process has data for it (under the correctness of the progress tracking protocol). It could have been a symptom of an unclean exit, but the symptom vanish (or was mitigated) by a delay post-computation before exiting the thread.

Perhaps the PR should be broadened to better detect unclean exits and point fingers at the remote connections that seem to be at fault. This fix *should* be an improvement, independently.

*Edit*: Importantly, this PR has not been tested in the wild yet. It is just chilling here and will not be merged without some testing to see if it does deflect the buggy shutdown, and if crashes remain we can try and extend the PR with further fixes.
