### PR TITLE
logging examples

### DIFF
--- a/examples/logging-recv.rs
+++ b/examples/logging-recv.rs
@@ -1,0 +1,32 @@
+extern crate timely;
+
+use std::net::TcpListener;
+use timely::dataflow::operators::Inspect;
+use timely::dataflow::operators::capture::{EventReader, Replay};
+use timely::progress::nested::product::Product;
+use timely::progress::timestamp::RootTimestamp;
+use timely::logging::{TimelySetup, TimelyEvent};
+
+fn main() {
+    timely::execute_from_args(std::env::args(), |worker| {
+
+        let source_peers = std::env::args().nth(1).unwrap().parse::<usize>().unwrap();
+
+        // create replayers from disjoint partition of source worker identifiers.
+        let replayers =
+        (0 .. source_peers)
+            .filter(|i| i % worker.peers() == worker.index())
+            .map(|i| TcpListener::bind(format!("127.0.0.1:{}", 8000 + i)).unwrap())
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|l| l.incoming().next().unwrap().unwrap())
+            .map(|r| EventReader::<Product<RootTimestamp, u64>,(u64, TimelySetup, TimelyEvent),_>::new(r))
+            .collect::<Vec<_>>();
+
+        worker.dataflow(|scope| {
+            replayers
+                .replay_into(scope)
+                .inspect(|x| println!("replayed: {:?}", x));
+        })
+    }).unwrap(); // asserts error-free execution
+}

--- a/examples/logging-send.rs
+++ b/examples/logging-send.rs
@@ -1,0 +1,66 @@
+extern crate timely;
+
+use timely::dataflow::InputHandle;
+use timely::dataflow::operators::{Input, Exchange, Probe};
+
+use timely::dataflow::operators::capture::EventWriter;
+
+fn main() {
+    // initializes and runs a timely dataflow.
+
+    use timely::logging::{LoggerConfig, EventPusherTee};
+    let logger_config = LoggerConfig::new(
+        |setup| {
+            use std::net::TcpStream;
+            let addr = format!("127.0.0.1:{}", 8000 + setup.index);
+            let send = TcpStream::connect(addr).unwrap();
+            EventWriter::new(send)
+        },
+        |_setup| {
+            // No support for communication threads in this example.
+            unimplemented!();
+            use std::net::TcpStream;
+            let addr = format!("127.0.0.1:{}", 8001);
+            let send = TcpStream::connect(addr).unwrap();
+            EventWriter::new(send)
+        }
+    );
+
+    timely::execute_from_args_logging(std::env::args(), logger_config, |worker| {
+
+        let batch = std::env::args().nth(1).unwrap().parse::<usize>().unwrap();
+        let rounds = std::env::args().nth(2).unwrap().parse::<usize>().unwrap();
+        let mut input = InputHandle::new();
+
+        // create a new input, exchange data, and inspect its output
+        let probe = worker.dataflow(|scope|
+            scope
+                .input_from(&mut input)
+                .exchange(|&x| x as u64)
+                .probe()
+        );
+
+
+        let timer = std::time::Instant::now();
+
+        for round in 0 .. rounds {
+
+            for i in 0 .. batch {
+                input.send(i);
+            }
+            input.advance_to(round);
+
+            while probe.less_than(input.time()) {
+                worker.step();
+            }
+
+        }
+
+        let volume = (rounds * batch) as f64;
+        let elapsed = timer.elapsed();
+        let seconds = elapsed.as_secs() as f64 + (f64::from(elapsed.subsec_nanos())/1000000000.0);
+
+        println!("{:?}\tworker {} complete; rate: {:?}", timer.elapsed(), worker.index(), volume / seconds);
+
+    }).unwrap();
+}


### PR DESCRIPTION
This PR adds two examples, `logging_send.rs` and `logging_recv.rs`. They are meant to be examples of how to enable and observe timely logging. They are not obviously the best examples, but they should give a taste for one way to monitor timely computations live.

If you open two shells, navigate to the timely directory, you should be able to type

    cargo run --example logging-recv -- 1

which will start up the logging listener. For .. reasons .. this is happening over a TCP socket (the easiest way for me to get a live binary stream).

In your other shell, you can type

    cargo run --example logging-send -- 1000 10000000

which will start up a massive exchange microbenchmark, repeatedly sending 1,000 records and synchronizing, repeating 10,000,000 times. You should see output that looks like

```
echidnatron% cargo run --example logging-recv -- 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/examples/logging-recv 1`
replayed: (1526320988930924002, TimelySetup { index: 0 }, Operates(OperatesEvent { id: 0, addr: [0, 0, 1], name: "Input" }))
replayed: (1526320988931086202, TimelySetup { index: 0 }, Channels(ChannelsEvent { id: 1, scope_addr: [0, 0], source: (1, 0), target: (2, 0) }))
replayed: (1526320988931173446, TimelySetup { index: 0 }, Operates(OperatesEvent { id: 2, addr: [0, 0, 2], name: "Exchange" }))
replayed: (1526320988931250124, TimelySetup { index: 0 }, Channels(ChannelsEvent { id: 3, scope_addr: [0, 0], source: (2, 0), target: (3, 0) }))
replayed: (1526320988931267648, TimelySetup { index: 0 }, Operates(OperatesEvent { id: 4, addr: [0, 0, 3], name: "Probe" }))
replayed: (1526320988931597789, TimelySetup { index: 0 }, CommChannels(CommChannelsEvent { comm_channel: None, comm_channel_kind: Progress }))
replayed: (1526320988931992460, TimelySetup { index: 0 }, Messages(MessagesEvent { is_send: true, channel: 1, comm_channel: None, source: 0, target: 0, seq_no: 0, length: 1000 }))
replayed: (1526320988932141162, TimelySetup { index: 0 }, Messages(MessagesEvent { is_send: true, channel: 1, comm_channel: None, source: 0, target: 0, seq_no: 1, length: 1000 }))
...
```

which should fly by *fast*. Lots is going on. At the beginning it tells you about the dataflow assembly, and then you start to get a stream of all of the scheduling events going on in the system. A lot of these are pretty dull (not much happens in the event).

If you check out `logging_recv.rs`, you'll notice that we've just imported a timely stream, and indeed all of the logging events are a timely stream timestamped with the recorded nanosecond of the worker. They have different types, and you can totally wire up a custom timely computation based on the log events that come past. Probably some filtering is in order!

More details to follow.