### PR TITLE
Update sort for rand 0.5

### DIFF
--- a/sort/Cargo.toml
+++ b/sort/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 rand="*"
 
 [dev-dependencies]
-rand="0.4"
+rand="0.5"
 
 [profile.release]
 opt-level = 3

--- a/sort/src/bin/profile.rs
+++ b/sort/src/bin/profile.rs
@@ -1,7 +1,7 @@
 extern crate rand;
 extern crate timely_sort as haeoua;
 
-use rand::{SeedableRng, StdRng, Rand};
+use rand::{SeedableRng, distributions::Distribution, distributions::Standard, prng::Hc128Rng};
 use haeoua::*;
 
 fn main() {
@@ -41,14 +41,20 @@ fn test_threads<L: Fn()+Send+Sync+'static>(threads: usize, logic: L) -> f64 {
     elapsed.as_secs() as f64 + (elapsed.subsec_nanos() as f64) / 1000000000.0
 }
 
-fn test_radix<T: Ord+Copy+Rand+Unsigned, R: RadixSorter<(T,T),T>>(size: usize, iters: usize) {
+fn test_radix<T, R>(size: usize, iters: usize)
+  where
+    T: Ord+Copy+Unsigned,
+    R: RadixSorter<(T,T),T>,
+    Standard: Distribution<T>,
+{
 
-    let seed: &[_] = &[1, 2, 3, 4];
-    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    let seed = [3u8; 32];
+    let mut rng: Hc128Rng = SeedableRng::from_seed(seed);
 
     let mut sorter = R::new();
     for _ in 0..size {
-        sorter.push(<(T, T) as Rand>::rand(&mut rng), &|x| x.0);
+        let tup: (T, T) = (Standard.sample(&mut rng), Standard.sample(&mut rng));
+        sorter.push(tup, &|x| x.0);
     }
     let mut vector = sorter.finish(&|x| x.0);
     sorter.sort(&mut vector, &|x| x.1);
@@ -59,14 +65,19 @@ fn test_radix<T: Ord+Copy+Rand+Unsigned, R: RadixSorter<(T,T),T>>(size: usize, i
     }
 }
 
-fn test_sort_by<T: Ord+Rand>(size: usize, iters: usize) {
+fn test_sort_by<T>(size: usize, iters: usize)
+  where
+    T: Ord,
+    Standard: Distribution<T>,
+{
 
-    let seed: &[_] = &[1, 2, 3, 4];
-    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    let seed = [3u8; 32];
+    let mut rng: Hc128Rng = SeedableRng::from_seed(seed);
 
     let mut vector = Vec::<(T, T)>::with_capacity(size);
     for _ in 0..size {
-        vector.push(<(T, T) as Rand>::rand(&mut rng));
+        let tup: (T, T) = (Standard.sample(&mut rng), Standard.sample(&mut rng));
+        vector.push(tup);
     }
 
     for _ in 0 .. iters {
@@ -75,14 +86,19 @@ fn test_sort_by<T: Ord+Rand>(size: usize, iters: usize) {
     }
 }
 
-fn test_sort_unstable_by<T: Ord+Rand>(size: usize, iters: usize) {
+fn test_sort_unstable_by<T>(size: usize, iters: usize)
+  where
+    T: Ord,
+    Standard: Distribution<T>,
+{
 
-    let seed: &[_] = &[1, 2, 3, 4];
-    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    let seed = [3u8; 32];
+    let mut rng: Hc128Rng = SeedableRng::from_seed(seed);
 
     let mut vector = Vec::<(T, T)>::with_capacity(size);
     for _ in 0..size {
-        vector.push(<(T, T) as Rand>::rand(&mut rng));
+        let tup: (T, T) = (Standard.sample(&mut rng), Standard.sample(&mut rng));
+        vector.push(tup);
     }
 
     for _ in 0 .. iters {


### PR DESCRIPTION
Rand 0.5 has design improvements but also breaking changes: 
https://www.reddit.com/r/rust/comments/8l95zk/rand_050_released/.

I flipped away from StdRng because of the warning in the Rand source code:
https://github.com/rust-lang-nursery/rand/blob/98b940fb1a3cd9e4f84e5b90e5ac003f5e123387/src/rngs/mod.rs#L86