### PR TITLE
Add/AddAssign for Product inner

### DIFF
--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -21,7 +21,7 @@ fn main() {
                 move |_, _, notificator| {
                     while let Some((cap, _count)) = notificator.next() {
                         let mut time = cap.time().clone();
-                        time.inner += 1;
+                        time += 1;
                         if time.inner < iterations {
                             notificator.notify_at(cap.delayed(&time));
                         }

--- a/src/progress/nested/product.rs
+++ b/src/progress/nested/product.rs
@@ -96,3 +96,17 @@ impl Empty for () { }
 impl<T1: Empty, T2: Empty> Empty for Product<T1, T2> { }
 
 impl<T1, T2> TotalOrder for Product<T1, T2> where T1: Empty, T2: TotalOrder { }
+
+impl<TO, I: ::std::ops::Add<Output=I>> ::std::ops::Add<I> for Product<TO, I> {
+    type Output = Product<TO, I>;
+
+    fn add(self, other: I) -> Self::Output {
+        Product::new(self.outer, self.inner + other)
+    }
+}
+
+impl<TO, I: ::std::ops::AddAssign> ::std::ops::AddAssign<I> for Product<TO, I> {
+    fn add_assign(&mut self, other: I) {
+        self.inner += other
+    }
+}


### PR DESCRIPTION
Add convenience `Add`/`AddAssign` implementations for the `Product` type. The implementation can be used to directly increment the inner dimension.

An alternative with less ambiguity would be to restrict `TO` to `RootTimestamp`.