### PR TITLE
Add Branch and BranchWhen operators

### DIFF
--- a/src/dataflow/operators/branch.rs
+++ b/src/dataflow/operators/branch.rs
@@ -1,0 +1,128 @@
+//! Operators that separate one stream into two streams based on some condition
+
+use dataflow::channels::pact::Pipeline;
+use dataflow::operators::generic::builder_rc::OperatorBuilder;
+use dataflow::{Scope, Stream};
+use Data;
+
+/// Extension trait for `Stream`.
+pub trait Branch<S: Scope, D: Data> {
+    /// Takes one input stream and splits it into two output streams.
+    /// For each record, the supplied closure is called with a reference to
+    /// the data and its time. If it returns true, the record will be sent
+    /// to the second returned stream, otherwise it will be sent to the first.
+    ///
+    /// If the result of the closure only depends on the time, not the data,
+    /// `branch_when` should be used instead.
+    ///
+    /// #Examples
+    /// ```
+    /// use timely::dataflow::operators::{ToStream, Branch, Inspect};
+    ///
+    /// timely::example(|scope| {
+    ///     let (odd, even) = (0..10)
+    ///         .to_stream(scope)
+    ///         .branch(|_time, x| *x % 2 == 0);
+    ///
+    ///     even.inspect(|x| println!("even numbers: {:?}", x));
+    ///     odd.inspect(|x| println!("odd numbers: {:?}", x));
+    /// });
+    /// ```
+    fn branch(
+        &self,
+        condition: impl Fn(&S::Timestamp, &D) -> bool + 'static,
+    ) -> (Stream<S, D>, Stream<S, D>);
+}
+
+impl<S: Scope, D: Data> Branch<S, D> for Stream<S, D> {
+    fn branch(
+        &self,
+        condition: impl Fn(&S::Timestamp, &D) -> bool + 'static,
+    ) -> (Stream<S, D>, Stream<S, D>) {
+        let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
+
+        let mut input = builder.new_input(self, Pipeline);
+        let (mut output1, stream1) = builder.new_output();
+        let (mut output2, stream2) = builder.new_output();
+
+        builder.build(move |_| {
+            move |_frontiers| {
+                let mut output1_handle = output1.activate();
+                let mut output2_handle = output2.activate();
+
+                input.for_each(|time, data| {
+                    let mut out1 = output1_handle.session(&time);
+                    let mut out2 = output2_handle.session(&time);
+                    for datum in data.drain(..) {
+                        if condition(&time.time(), &datum) {
+                            out2.give(datum);
+                        } else {
+                            out1.give(datum);
+                        }
+                    }
+                });
+            }
+        });
+
+        (stream1, stream2)
+    }
+}
+
+/// Extension trait for `Stream`.
+pub trait BranchWhen<S: Scope, D: Data> {
+    /// Takes one input stream and splits it into two output streams.
+    /// For each time, the supplied closure is called. If it returns true,
+    /// the records for that will be sent to the second returned stream, otherwise
+    /// they will be sent to the first.
+    /// 
+    /// #Examples
+    /// ```
+    /// use timely::dataflow::operators::{ToStream, BranchWhen, Inspect, Delay};
+    /// use timely::progress::timestamp::RootTimestamp;
+    ///
+    /// timely::example(|scope| {
+    ///     let (before_five, after_five) = (0..10)
+    ///         .to_stream(scope)
+    ///         .delay(|x,t| RootTimestamp::new(*x)) // data 0..10 at time 0..10
+    ///         .branch_when(|time| time.inner >= 5);
+    ///
+    ///     before_five.inspect(|x| println!("Times 0-4: {:?}", x));
+    ///     after_five.inspect(|x| println!("Times 5 and later: {:?}", x));
+    /// });
+    /// ```
+    fn branch_when(
+        &self,
+        condition: impl Fn(&S::Timestamp) -> bool + 'static,
+    ) -> (Stream<S, D>, Stream<S, D>);
+}
+
+impl<S: Scope, D: Data> BranchWhen<S, D> for Stream<S, D> {
+    fn branch_when(
+        &self,
+        condition: impl Fn(&S::Timestamp) -> bool + 'static,
+    ) -> (Stream<S, D>, Stream<S, D>) {
+        let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
+
+        let mut input = builder.new_input(self, Pipeline);
+        let (mut output1, stream1) = builder.new_output();
+        let (mut output2, stream2) = builder.new_output();
+
+        builder.build(move |_| {
+            move |_frontiers| {
+                let mut output1_handle = output1.activate();
+                let mut output2_handle = output2.activate();
+
+                input.for_each(|time, data| {
+                    let mut out = if condition(&time.time()) {
+                        output2_handle.session(&time)
+                    } else {
+                        output1_handle.session(&time)
+                    };
+                    out.give_content(data);
+                });
+            }
+        });
+
+        (stream1, stream2)
+    }
+}

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -24,6 +24,7 @@ pub use self::broadcast::Broadcast;
 pub use self::probe::Probe;
 pub use self::to_stream::ToStream;
 pub use self::capture::Capture;
+pub use self::branch::{Branch, BranchWhen};
 
 pub use self::generic::{Unary, Binary, Operator};
 pub use self::generic::{Notificator, FrontierNotificator};
@@ -46,6 +47,7 @@ pub mod broadcast;
 pub mod probe;
 pub mod to_stream;
 pub mod capture;
+pub mod branch;
 
 pub mod aggregation;
 pub mod generic;


### PR DESCRIPTION
This adds the branch operator that came up in #165 and another operator called `branch_when` that does almost the same but only concerns itself with the times, not the data itself. They split one stream into two depending on a condition that gets passed as a closure.

I've been using these for a while now and since they're so generic I figured I should contribute them here. My only concern would be the overlap between these and `partition`, but they are definitely much more ergonomic to use if you just want a basic "if/else" type functionality.

Related question: Would it be worth it to introduce an even more generic operator that simply does any 1 input -> 2 output operation, in a similar way to the `binary` operator (just 1 -> 2 instead of 2 -> 1)? If such an operator existed, these two could be rewritten a little shorter than they are now, but I'm not sure if there are many use cases for that kind of thing.