### PR TITLE
Distinct output capabilities

### DIFF
--- a/src/dataflow/operators/generic/builder_rc.rs
+++ b/src/dataflow/operators/generic/builder_rc.rs
@@ -88,12 +88,13 @@ impl<G: Scope> OperatorBuilder<G> {
 
         let (tee, stream) = self.builder.new_output_connection(connection);
 
-        self.internal.borrow_mut().push(Rc::new(RefCell::new(ChangeBatch::new())));
+        let internal = Rc::new(RefCell::new(ChangeBatch::new()));
+        self.internal.borrow_mut().push(internal.clone());
 
         let mut buffer = PushBuffer::new(PushCounter::new(tee));
         self.produced.push(buffer.inner().produced().clone());
 
-        (OutputWrapper::new(buffer), stream)
+        (OutputWrapper::new(buffer, internal), stream)
     }
 
     /// Creates an operator implementation from supplied logic constructor.
@@ -145,12 +146,6 @@ impl<G: Scope> OperatorBuilder<G> {
                 let mut borrow = self_internal_borrow[index].borrow_mut();
                 internal[index].extend(borrow.drain());
             }
-
-            // for index in 0 .. internal.len() {
-            //     let mut borrow = self_internal.borrow_mut();
-            //     internal[index].extend(borrow.iter().cloned());
-            // }
-            // self_internal.borrow_mut().clear();
 
             // move batches of produced changes.
             for index in 0 .. produced.len() {

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -24,7 +24,7 @@ use dataflow::operators::capability::CapabilityTrait;
 /// Handle to an operator's input stream.
 pub struct InputHandle<T: Timestamp, D, P: Pull<Bundle<T, D>>> {
     pull_counter: PullCounter<T, D, P>,
-    internal: Rc<RefCell<ChangeBatch<T>>>,
+    internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>,
     logging: Logger,
 }
 
@@ -43,7 +43,7 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
     /// Returns `None` when there's no more data available.
     #[inline(always)]
     pub fn next(&mut self) -> Option<(CapabilityRef<T>, RefOrMut<Vec<D>>)> {
-        let internal = &mut self.internal;
+        let internal = &self.internal;
         self.pull_counter.next().map(|bundle| {
             match bundle.as_ref_or_mut() {
                 RefOrMut::Ref(bundle) => {
@@ -141,7 +141,7 @@ pub fn _access_pull_counter<T: Timestamp, D, P: Pull<Bundle<T, D>>>(input: &mut 
 
 /// Constructs an input handle.
 /// Declared separately so that it can be kept private when `InputHandle` is re-exported.
-pub fn new_input_handle<T: Timestamp, D, P: Pull<Bundle<T, D>>>(pull_counter: PullCounter<T, D, P>, internal: Rc<RefCell<ChangeBatch<T>>>, logging: Logger) -> InputHandle<T, D, P> {
+pub fn new_input_handle<T: Timestamp, D, P: Pull<Bundle<T, D>>>(pull_counter: PullCounter<T, D, P>, internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>, logging: Logger) -> InputHandle<T, D, P> {
     InputHandle {
         pull_counter,
         internal,

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -348,7 +348,9 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         let mut input = builder.new_input(self, pact);
         let (mut output, stream) = builder.new_output();
 
-        builder.build(move |capability| {
+        builder.build(move |mut capabilities| {
+            // `capabilities` should be a single-element vector.
+            let capability = capabilities.pop().unwrap();
             let mut logic = constructor(capability, new_operator_info(index));
             move |frontiers| {
                 let mut input_handle = FrontieredInputHandle::new(&mut input, &frontiers[0]);
@@ -397,7 +399,9 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         let (mut output, stream) = builder.new_output();
         builder.set_notify(false);
 
-        builder.build(move |capability| {
+        builder.build(move |mut capabilities| {
+            // `capabilities` should be a single-element vector.
+            let capability = capabilities.pop().unwrap();
             let mut logic = constructor(capability, new_operator_info(index));
             move |_frontiers| {
                 let mut output_handle = output.activate();
@@ -426,7 +430,9 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         let mut input2 = builder.new_input(other, pact2);
         let (mut output, stream) = builder.new_output();
 
-        builder.build(move |capability| {
+        builder.build(move |mut capabilities| {
+            // `capabilities` should be a single-element vector.
+            let capability = capabilities.pop().unwrap();
             let mut logic = constructor(capability, new_operator_info(index));
             move |frontiers| {
                 let mut input1_handle = FrontieredInputHandle::new(&mut input1, &frontiers[0]);
@@ -485,7 +491,9 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         let (mut output, stream) = builder.new_output();
         builder.set_notify(false);
 
-        builder.build(move |capability| {
+        builder.build(move |mut capabilities| {
+            // `capabilities` should be a single-element vector.
+            let capability = capabilities.pop().unwrap();
             let mut logic = constructor(capability, new_operator_info(index));
             move |_frontiers| {
                 let mut output_handle = output.activate();
@@ -504,7 +512,7 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let mut input = builder.new_input(self, pact);
 
-        builder.build(|_capability| {
+        builder.build(|_capabilities| {
             move |frontiers| {
                 let mut input_handle = FrontieredInputHandle::new(&mut input, &frontiers[0]);
                 logic(&mut input_handle);
@@ -561,7 +569,9 @@ where
     let (mut output, stream) = builder.new_output();
     builder.set_notify(false);
 
-    builder.build(|capability| {
+    builder.build(move |mut capabilities| {
+        // `capabilities` should be a single-element vector.
+        let capability = capabilities.pop().unwrap();
         let mut logic = constructor(capability);
         move |_frontier| {
             logic(&mut output.activate());


### PR DESCRIPTION
This PR adds support for distinguished output capabilities, where each `Capability<T>` is bound to a specific operator output. A `CapabilityRef<T>` is able to be downgraded or retained for specific outputs; for compatibility the methods without the output argument use the first output. The `CapabilityTrait` now provides a method that validates the capability for use with an output, which performs `Rc::ptr_eq` on the buffers they would be updating (and in the case of `CapabilityRef` check each possible buffer, corresponding to the outputs).

This adds a bit of ergonomic complexity for folks writing custom operators with multiple outputs, but it is important for anyone who wants to distinguish their output capabilities to enable concurrency that would otherwise be falsely prevented.

This PR does *not* validate the compatibility of the capabilities production according to the operator summary, so a user can still create a capability from an input for an output that they have claimed cannot be reached internally. This would be great to add, but might increase the per-capability reasoning substantially. Future work!

Fixes #186 