### PR TITLE
Subscope rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - Many logging events have been rationalized. Operators and Channels should all have a worker-unique identifier that can be used to connect their metadata with events involving them. Previously this was a bit of a shambles.
 
+- The `Scope` method `scoped` now allows supports new scopes with non-`Product` timestamps. Instead, the new timestamp must implement `Refines<_>` of the parent timestamp. This is the case for `Product` timestamps, but each timestamp also refines itself (allowing logical regions w/o changing the timestamp), and other timestamp combinators (e.g. Lexicographic) can be used.
+
+- Timestamps no longer need to be `Product<RootTimestamp,_>`. Instead, the `_` can be used as the timestamp. The exception here is that the creation of loop variables requires a `Product<_,_>` structured timestamp, and so as much as you might like to have a scope with a `usize` timestamp and a loop, and you *should* be able to, you cannot yet without making the type `Product<(), usize>`.
+
+- The `RootTimestamp` and `RootSummary` types have been excised. Where you previously used `Product<RootTimestamp,T>` you can now use `Product<(),T>`, or even better just `T`. The requirement of a worker's `dataflow()` method is that the timestamp type implement `Refines<()>`, which .. ideally would be true for all timestamps but we can't have a blanket implementation until specialization lands (I believe).
+
 ## 0.7.0
 
 ### Added

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -1,8 +1,7 @@
 extern crate timely;
 
+use timely::progress::nested::product::Product;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::progress::timestamp::RootTimestamp;
-
 use timely::dataflow::operators::{LoopVariable, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
 
@@ -17,7 +16,7 @@ fn main() {
             stream.unary_notify(
                 Pipeline,
                 "Barrier",
-                vec![RootTimestamp::new(0)],
+                vec![Product::new((), 0)],
                 move |_, _, notificator| {
                     while let Some((cap, _count)) = notificator.next() {
                         let mut time = cap.time().clone();

--- a/examples/flow_controlled.rs
+++ b/examples/flow_controlled.rs
@@ -3,8 +3,6 @@ extern crate timely;
 use timely::dataflow::operators::flow_controlled::{iterator_source, IteratorSourceInput};
 use timely::dataflow::operators::{probe, Probe, Inspect};
 
-use timely::progress::timestamp::RootTimestamp;
-
 fn main() {
     timely::execute_from_args(std::env::args(), |worker| {
         let mut input = (0u64..100000).peekable();
@@ -22,7 +20,7 @@ fn main() {
                         Some(IteratorSourceInput {
                             lower_bound: Default::default(),
                             data: vec![
-                                (RootTimestamp::new(next_t),
+                                (next_t,
                                  input.by_ref().take(10).map(|x| (/* "timestamp" */ x, x)).collect::<Vec<_>>())],
                             target: *prev_t,
                         })

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,6 @@
 extern crate timely;
 
-use timely::dataflow::InputHandle;
+use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{Input, Exchange, Inspect, Probe};
 
 fn main() {
@@ -9,14 +9,15 @@ fn main() {
 
         let index = worker.index();
         let mut input = InputHandle::new();
+        let mut probe = ProbeHandle::new();
 
         // create a new input, exchange data, and inspect its output
-        let probe = worker.dataflow(|scope|
+        worker.dataflow(|scope| {
             scope.input_from(&mut input)
                  .exchange(|x| *x)
                  .inspect(move |x| println!("worker {}:\thello {}", index, x))
-                 .probe()
-        );
+                 .probe_with(&mut probe);
+        });
 
         // introduce data and watch!
         for round in 0..10 {

--- a/examples/logging-recv.rs
+++ b/examples/logging-recv.rs
@@ -1,10 +1,10 @@
 extern crate timely;
 
 use std::net::TcpListener;
+use std::time::Duration;
+
 use timely::dataflow::operators::Inspect;
 use timely::dataflow::operators::capture::{EventReader, Replay};
-use timely::progress::nested::product::Product;
-use timely::progress::timestamp::RootTimestamp;
 use timely::logging::{TimelySetup, TimelyEvent};
 
 fn main() {
@@ -20,7 +20,7 @@ fn main() {
             .collect::<Vec<_>>()
             .into_iter()
             .map(|l| l.incoming().next().unwrap().unwrap())
-            .map(|r| EventReader::<Product<RootTimestamp, u64>,(u64, TimelySetup, TimelyEvent),_>::new(r))
+            .map(|r| EventReader::<Duration,(Duration,TimelySetup,TimelyEvent),_>::new(r))
             .collect::<Vec<_>>();
 
         worker.dataflow(|scope| {

--- a/examples/loopdemo.rs
+++ b/examples/loopdemo.rs
@@ -26,7 +26,7 @@ fn main() {
             let stream = scope.input_from(&mut input);
 
             scope
-                .scoped(|child| {
+                .iterative(|child| {
 
                     let (loop_handle, loop_stream) = child.loop_variable(usize::max_value(), 1);
 

--- a/examples/loopdemo.rs
+++ b/examples/loopdemo.rs
@@ -1,0 +1,131 @@
+extern crate timely;
+
+use timely::dataflow::{Scope, InputHandle, ProbeHandle};
+use timely::dataflow::operators::{Input, LoopVariable, Enter, Concat, Map, Filter, ConnectLoop, Leave, Probe};
+
+fn main() {
+
+    let mut args = std::env::args();
+    args.next();
+    let rate: usize = args.next().expect("Must specify rate").parse().expect("Rate must be an usize");
+    let duration_s: usize = args.next().expect("Must specify duration_s").parse().expect("duration_s must be an usize");
+
+    timely::execute_from_args(args, move |worker| {
+
+        let index = worker.index();
+        let peers = worker.peers();
+
+        let timer = std::time::Instant::now();
+
+        let mut input = InputHandle::new();
+        let mut probe = ProbeHandle::new();
+
+        // Create a dataflow that discards input data (just syncronizes).
+        worker.dataflow(|scope| {
+
+            let stream = scope.input_from(&mut input);
+
+            scope
+                .scoped(|child| {
+
+                    let (loop_handle, loop_stream) = child.loop_variable(usize::max_value(), 1);
+
+                    let step =
+                    stream
+                        .enter(child)
+                        .concat(&loop_stream)
+                        .map(|x| if x % 2 == 0 { x / 2 } else { 3 * x + 1 })
+                        .filter(|x| x > &1);
+
+                    step.connect_loop(loop_handle);
+                    step.leave()
+                })
+                .probe_with(&mut probe);
+        });
+
+        let ns_per_request = 1_000_000_000 / rate;
+        let mut insert_counter = index;           // counts up as we insert records.
+        let mut retire_counter = index;           // counts up as we retire records.
+
+        let mut inserted_ns = 0;
+
+        // We repeatedly consult the elapsed time, and introduce any data now considered available.
+        // At the same time, we observe the output and record which inputs are considered retired.
+
+        let mut counts = vec![[0u64; 16]; 64];
+
+        let counter_limit = rate * duration_s;
+        while retire_counter < counter_limit {
+
+            // Open-loop latency-throughput test, parameterized by offered rate `ns_per_request`.
+            let elapsed = timer.elapsed();
+            let elapsed_ns = elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64);
+
+            // Determine completed ns.
+            let acknowledged_ns: u64 = probe.with_frontier(|frontier| frontier[0]);
+
+            // Notice any newly-retired records.
+            while ((retire_counter * ns_per_request) as u64) < acknowledged_ns && retire_counter < counter_limit {
+                let requested_at = (retire_counter * ns_per_request) as u64;
+                let latency_ns = elapsed_ns - requested_at;
+
+                let count_index = latency_ns.next_power_of_two().trailing_zeros() as usize;
+                let low_bits = ((elapsed_ns - requested_at) >> (count_index - 5)) & 0xF;
+                counts[count_index][low_bits as usize] += 1;
+
+                retire_counter += peers;
+            }
+
+            // Now, should we introduce more records before stepping the worker?
+            // Three choices here:
+            //
+            //   1. Wait until previous batch acknowledged.
+            //   2. Tick at most once every millisecond-ish.
+            //   3. Geometrically increasing outstanding batches.
+
+            // Technique 1:
+            // let target_ns = if acknowledged_ns >= inserted_ns { elapsed_ns } else { inserted_ns };
+
+            // Technique 2:
+            // let target_ns = elapsed_ns & !((1 << 20) - 1);
+
+            // Technique 3:
+            let scale = (inserted_ns - acknowledged_ns).next_power_of_two();
+            let target_ns = elapsed_ns & !(scale - 1);
+
+            if inserted_ns < target_ns {
+
+                while ((insert_counter * ns_per_request) as u64) < target_ns {
+                    input.send(insert_counter);
+                    insert_counter += peers;
+                }
+                input.advance_to(target_ns);
+                inserted_ns = target_ns;
+            }
+
+            worker.step();
+        }
+
+        // Report observed latency measurements.
+        if index == 0 {
+
+            let mut results = Vec::new();
+            let total = counts.iter().map(|x| x.iter().sum::<u64>()).sum();
+            let mut sum = 0;
+            for index in (10 .. counts.len()).rev() {
+                for sub in (0 .. 16).rev() {
+                    if sum > 0 && sum < total {
+                        let latency = (1 << (index-1)) + (sub << (index-5));
+                        let fraction = (sum as f64) / (total as f64);
+                        results.push((latency, fraction));
+                    }
+                    sum += counts[index][sub];
+                }
+            }
+            for (latency, fraction) in results.drain(..).rev() {
+                println!("{}\t{}", latency, fraction);
+            }
+        }
+
+    }).unwrap();
+}

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -9,6 +9,7 @@ use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{LoopVariable, ConnectLoop, Probe};
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::channels::pact::Exchange;
+use timely::progress::timestamp::RootTimestamp;
 
 fn main() {
 
@@ -170,7 +171,7 @@ fn main() {
             input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
         }
 
-        input.advance_to(1);
+        input.advance_to(RootTimestamp::new(1));
 
         while probe.less_than(input.time()) {
             worker.step();
@@ -179,7 +180,7 @@ fn main() {
         for i in 1 .. 1000 {
             input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
             input.send(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)), -1));
-            input.advance_to(1 + i);
+            input.advance_to(RootTimestamp::new(1 + i));
             while probe.less_than(input.time()) {
                 worker.step();
             }

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -4,12 +4,11 @@ extern crate timely;
 use std::collections::HashMap;
 use rand::{Rng, SeedableRng, StdRng};
 
+use timely::progress::nested::product::Product;
 use timely::dataflow::{InputHandle, ProbeHandle};
-
 use timely::dataflow::operators::{LoopVariable, ConnectLoop, Probe};
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::channels::pact::Exchange;
-use timely::progress::timestamp::RootTimestamp;
 
 fn main() {
 
@@ -171,7 +170,7 @@ fn main() {
             input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
         }
 
-        input.advance_to(RootTimestamp::new(1));
+        input.advance_to(Product::new((), 1));
 
         while probe.less_than(input.time()) {
             worker.step();
@@ -180,7 +179,7 @@ fn main() {
         for i in 1 .. 1000 {
             input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
             input.send(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)), -1));
-            input.advance_to(RootTimestamp::new(1 + i));
+            input.advance_to(Product::new((), 1 + i));
             while probe.less_than(input.time()) {
                 worker.step();
             }

--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -1,0 +1,116 @@
+extern crate timely;
+
+use timely::dataflow::{InputHandle, ProbeHandle};
+use timely::dataflow::operators::{Input, Filter, Probe};
+
+fn main() {
+
+    let mut args = std::env::args();
+    args.next();
+    let rate: usize = args.next().expect("Must specify rate").parse().expect("Rate must be an usize");
+    let duration_s: usize = args.next().expect("Must specify duration_s").parse().expect("duration_s must be an usize");
+
+    timely::execute_from_args(args, move |worker| {
+
+        let index = worker.index();
+        let peers = worker.peers();
+
+        let timer = std::time::Instant::now();
+
+        let mut input = InputHandle::new();
+        let mut probe = ProbeHandle::new();
+
+        // Create a dataflow that discards input data (just syncronizes).
+        worker.dataflow(|scope| {
+            scope
+                .input_from(&mut input)     // read input.
+                .filter(|_| false)          // do nothing.
+                .probe_with(&mut probe);    // observe output.
+        });
+
+        let ns_per_request = 1_000_000_000 / rate;
+        let mut insert_counter = index;           // counts up as we insert records.
+        let mut retire_counter = index;           // counts up as we retire records.
+
+        let mut inserted_ns = 0;
+
+        // We repeatedly consult the elapsed time, and introduce any data now considered available.
+        // At the same time, we observe the output and record which inputs are considered retired.
+
+        let mut counts = vec![[0u64; 16]; 64];
+
+        let counter_limit = rate * duration_s;
+        while retire_counter < counter_limit {
+
+            // Open-loop latency-throughput test, parameterized by offered rate `ns_per_request`.
+            let elapsed = timer.elapsed();
+            let elapsed_ns = elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64);
+
+            // Determine completed ns.
+            let acknowledged_ns: u64 = probe.with_frontier(|frontier| frontier[0]);
+
+            // Notice any newly-retired records.
+            while ((retire_counter * ns_per_request) as u64) < acknowledged_ns && retire_counter < counter_limit {
+                let requested_at = (retire_counter * ns_per_request) as u64;
+                let latency_ns = elapsed_ns - requested_at;
+
+                let count_index = latency_ns.next_power_of_two().trailing_zeros() as usize;
+                let low_bits = ((elapsed_ns - requested_at) >> (count_index - 5)) & 0xF;
+                counts[count_index][low_bits as usize] += 1;
+
+                retire_counter += peers;
+            }
+
+            // Now, should we introduce more records before stepping the worker?
+            // Three choices here:
+            //
+            //   1. Wait until previous batch acknowledged.
+            //   2. Tick at most once every millisecond-ish.
+            //   3. Geometrically increasing outstanding batches.
+
+            // Technique 1:
+            // let target_ns = if acknowledged_ns >= inserted_ns { elapsed_ns } else { inserted_ns };
+
+            // Technique 2:
+            // let target_ns = elapsed_ns & !((1 << 20) - 1);
+
+            // Technique 3:
+            let scale = (inserted_ns - acknowledged_ns).next_power_of_two();
+            let target_ns = elapsed_ns & !(scale - 1);
+
+            if inserted_ns < target_ns {
+
+                while ((insert_counter * ns_per_request) as u64) < target_ns {
+                    input.send(insert_counter);
+                    insert_counter += peers;
+                }
+                input.advance_to(target_ns);
+                inserted_ns = target_ns;
+            }
+
+            worker.step();
+        }
+
+        // Report observed latency measurements.
+        if index == 0 {
+
+            let mut results = Vec::new();
+            let total = counts.iter().map(|x| x.iter().sum::<u64>()).sum();
+            let mut sum = 0;
+            for index in (10 .. counts.len()).rev() {
+                for sub in (0 .. 16).rev() {
+                    if sum > 0 && sum < total {
+                        let latency = (1 << (index-1)) + (sub << (index-5));
+                        let fraction = (sum as f64) / (total as f64);
+                        results.push((latency, fraction));
+                    }
+                    sum += counts[index][sub];
+                }
+            }
+            for (latency, fraction) in results.drain(..).rev() {
+                println!("{}\t{}", latency, fraction);
+            }
+        }
+
+    }).unwrap();
+}

--- a/examples/unordered_input.rs
+++ b/examples/unordered_input.rs
@@ -3,11 +3,11 @@ extern crate timely_communication;
 
 use timely::dataflow::operators::*;
 use timely_communication::Configuration;
-use timely::progress::timestamp::RootTimestamp;
+// use timely::progress::timestamp::RootTimestamp;
 
 fn main() {
     timely::execute(Configuration::Thread, |worker| {
-        let (mut input, mut cap) = worker.dataflow(|scope| {
+        let (mut input, mut cap) = worker.dataflow::<usize,_,_>(|scope| {
             let (input, stream) = scope.new_unordered_input();
             stream.inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));
             input
@@ -15,7 +15,7 @@ fn main() {
 
         for round in 0..10 {
             input.session(cap.clone()).give(round);
-            cap = cap.delayed(&RootTimestamp::new(round + 1));
+            cap = cap.delayed(&(round + 1));
             worker.step();
         }
     }).unwrap();

--- a/examples/wordcount.rs
+++ b/examples/wordcount.rs
@@ -17,7 +17,7 @@ fn main() {
         let exchange = Exchange::new(|x: &(String, i64)| (x.0).len() as u64);
 
         // create a new input, exchange data, and inspect its output
-        worker.dataflow(|scope| {
+        worker.dataflow::<usize,_,_>(|scope| {
             input.to_stream(scope)
                  .flat_map(|(text, diff): (String, i64)|
                     text.split_whitespace()

--- a/src/dataflow/operators/branch.rs
+++ b/src/dataflow/operators/branch.rs
@@ -80,13 +80,12 @@ pub trait BranchWhen<S: Scope, D: Data> {
     /// # Examples
     /// ```
     /// use timely::dataflow::operators::{ToStream, BranchWhen, Inspect, Delay};
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// timely::example(|scope| {
     ///     let (before_five, after_five) = (0..10)
     ///         .to_stream(scope)
-    ///         .delay(|x,t| RootTimestamp::new(*x)) // data 0..10 at time 0..10
-    ///         .branch_when(|time| time.inner >= 5);
+    ///         .delay(|x,t| *x) // data 0..10 at time 0..10
+    ///         .branch_when(|time| time >= &5);
     ///
     ///     before_five.inspect(|x| println!("Times 0-4: {:?}", x));
     ///     after_five.inspect(|x| println!("Times 5 and later: {:?}", x));

--- a/src/dataflow/operators/count.rs
+++ b/src/dataflow/operators/count.rs
@@ -17,7 +17,6 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// ```
     /// use timely::dataflow::operators::{ToStream, Accumulate, Capture};
     /// use timely::dataflow::operators::capture::Extract;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// let captured = timely::example(|scope| {
     ///     (0..10).to_stream(scope)
@@ -26,7 +25,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// });
     ///
     /// let extracted = captured.extract();
-    /// assert_eq!(extracted, vec![(RootTimestamp::new(0), vec![45])]);
+    /// assert_eq!(extracted, vec![(0, vec![45])]);
     /// ```
     fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, A>;
     /// Counts the number of records observed at each time.
@@ -36,7 +35,6 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// ```
     /// use timely::dataflow::operators::{ToStream, Accumulate, Capture};
     /// use timely::dataflow::operators::capture::Extract;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// let captured = timely::example(|scope| {
     ///     (0..10).to_stream(scope)
@@ -45,7 +43,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// });
     ///
     /// let extracted = captured.extract();
-    /// assert_eq!(extracted, vec![(RootTimestamp::new(0), vec![10])]);
+    /// assert_eq!(extracted, vec![(0, vec![10])]);
     /// ```
     fn count(&self) -> Stream<G, usize> {
         self.accumulate(0, |sum, data| *sum += data.len())

--- a/src/dataflow/operators/delay.rs
+++ b/src/dataflow/operators/delay.rs
@@ -19,8 +19,8 @@ pub trait Delay<G: Scope, D: Data> {
     ///
     /// # Examples
     ///
-    /// The following example takes the sequence `0..10` at time `RootTimestamp(0)`
-    /// and delays each element `i` to time `RootTimestamp(i)`.
+    /// The following example takes the sequence `0..10` at time `0`
+    /// and delays each element `i` to time `i`.
     ///
     /// ```
     /// use timely::dataflow::operators::{ToStream, Delay, Operator};
@@ -46,8 +46,8 @@ pub trait Delay<G: Scope, D: Data> {
     ///
     /// # Examples
     ///
-    /// The following example takes the sequence `0..10` at time `RootTimestamp(0)`
-    /// and delays each element `i` to time `RootTimestamp(i)`.
+    /// The following example takes the sequence `0..10` at time `0`
+    /// and delays each element `i` to time `i`.
     ///
     /// ```
     /// use timely::dataflow::operators::{ToStream, Delay, Operator};

--- a/src/dataflow/operators/delay.rs
+++ b/src/dataflow/operators/delay.rs
@@ -24,11 +24,10 @@ pub trait Delay<G: Scope, D: Data> {
     /// ```
     /// use timely::dataflow::operators::{ToStream, Delay, Operator};
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// timely::example(|scope| {
     ///     (0..10).to_stream(scope)
-    ///            .delay(|data, time| RootTimestamp::new(*data))
+    ///            .delay(|data, time| *data)
     ///            .sink(Pipeline, "example", |input| {
     ///                input.for_each(|time, data| {
     ///                    println!("data at time: {:?}", time);
@@ -46,17 +45,16 @@ pub trait Delay<G: Scope, D: Data> {
     ///
     /// # Examples
     ///
-    /// The following example takes the sequence `0..10` at time `RootTimestamp(0)`
-    /// and delays each batch (there is just one) to time `RootTimestamp(1)`.
+    /// The following example takes the sequence `0..10` at time `0`
+    /// and delays each batch (there is just one) to time `1`.
     ///
     /// ```
     /// use timely::dataflow::operators::{ToStream, Delay, Operator};
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// timely::example(|scope| {
     ///     (0..10).to_stream(scope)
-    ///            .delay_batch(|time| RootTimestamp::new(time.inner + 1))
+    ///            .delay_batch(|time| time + 1)
     ///            .sink(Pipeline, "example", |input| {
     ///                input.for_each(|time, data| {
     ///                    println!("data at time: {:?}", time);

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -11,7 +11,7 @@
 //!
 //! timely::example(|outer| {
 //!     let stream = (0..9).to_stream(outer);
-//!     let output = outer.scoped::<u64,_,_>(|inner| {
+//!     let output = outer.region(|inner| {
 //!         stream.enter(inner)
 //!               .inspect(|x| println!("in nested scope: {:?}", x))
 //!               .leave()
@@ -47,7 +47,7 @@ pub trait Enter<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9).to_stream(outer);
-    ///     let output = outer.scoped::<u64,_,_>(|inner| {
+    ///     let output = outer.region(|inner| {
     ///         stream.enter(inner).leave()
     ///     });
     /// });
@@ -68,7 +68,7 @@ pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9u64).to_stream(outer);
-    ///     let output = outer.scoped(|inner| {
+    ///     let output = outer.iterative(|inner| {
     ///         stream.enter_at(inner, |x| *x).leave()
     ///     });
     /// });
@@ -109,7 +109,7 @@ pub trait Leave<G: Scope, D: Data> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9).to_stream(outer);
-    ///     let output = outer.scoped::<u64,_,_>(|inner| {
+    ///     let output = outer.region(|inner| {
     ///         stream.enter(inner).leave()
     ///     });
     /// });

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -11,7 +11,7 @@
 //!
 //! timely::example(|outer| {
 //!     let stream = (0..9).to_stream(outer);
-//!     let output = outer.scoped::<u32,_,_>(|inner| {
+//!     let output = outer.scoped::<u64,_,_>(|inner| {
 //!         stream.enter(inner)
 //!               .inspect(|x| println!("in nested scope: {:?}", x))
 //!               .leave()
@@ -19,12 +19,12 @@
 //! });
 //! ```
 
-use std::default::Default;
+// use std::default::Default;
 
 use std::marker::PhantomData;
 
 use progress::Timestamp;
-use progress::nested::subgraph::{Source, Target};
+use progress::nested::{Refines, Source, Target};
 use progress::nested::product::Product;
 use Data;
 use communication::Push;
@@ -33,11 +33,11 @@ use dataflow::channels::{Bundle, Message};
 
 use worker::AsWorker;
 use dataflow::{Stream, Scope};
-use dataflow::scopes::Child;
+use dataflow::scopes::{Child, ScopeParent};
 use dataflow::operators::delay::Delay;
 
 /// Extension trait to move a `Stream` into a child of its current `Scope`.
-pub trait Enter<G: Scope, T: Timestamp, D: Data> {
+pub trait Enter<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> {
     /// Moves the `Stream` argument into a child of its current `Scope`.
     ///
     /// # Examples
@@ -47,13 +47,15 @@ pub trait Enter<G: Scope, T: Timestamp, D: Data> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9).to_stream(outer);
-    ///     let output = outer.scoped::<u32,_,_>(|inner| {
+    ///     let output = outer.scoped::<u64,_,_>(|inner| {
     ///         stream.enter(inner).leave()
     ///     });
     /// });
     /// ```
     fn enter<'a>(&self, &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D>;
 }
+
+use dataflow::scopes::child::Iterative;
 
 /// Extension trait to move a `Stream` into a child of its current `Scope` setting the timestamp for each element.
 pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {
@@ -65,27 +67,27 @@ pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {
     /// use timely::dataflow::operators::{EnterAt, Leave, ToStream};
     ///
     /// timely::example(|outer| {
-    ///     let stream = (0..9).to_stream(outer);
-    ///     let output = outer.scoped::<u32,_,_>(|inner| {
+    ///     let stream = (0..9u64).to_stream(outer);
+    ///     let output = outer.scoped(|inner| {
     ///         stream.enter_at(inner, |x| *x).leave()
     ///     });
     /// });
     /// ```
-    fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Child<'a, G, T>, initial: F) -> Stream<Child<'a, G, T>, D> ;
+    fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) -> Stream<Iterative<'a, G, T>, D> ;
 }
 
-impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, T, D>> EnterAt<G, T, D> for E {
-    fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Child<'a, G, T>, initial: F) ->
-        Stream<Child<'a, G, T>, D> {
-            self.enter(scope).delay(move |datum, time| Product::new(time.outer.clone(), initial(datum)))
+impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, Product<<G as ScopeParent>::Timestamp, T>, D>> EnterAt<G, T, D> for E {
+    fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) ->
+        Stream<Iterative<'a, G, T>, D> {
+            self.enter(scope).delay(move |datum, time| Product::new(time.clone().to_outer(), initial(datum)))
     }
 }
 
-impl<T: Timestamp, G: Scope, D: Data> Enter<G, T, D> for Stream<G, D> {
+impl<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> Enter<G, T, D> for Stream<G, D> {
     fn enter<'a>(&self, scope: &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D> {
 
-        let (targets, registrar) = Tee::<Product<G::Timestamp, T>, D>::new();
-        let ingress = IngressNub { targets: Counter::new(targets) };
+        let (targets, registrar) = Tee::<T, D>::new();
+        let ingress = IngressNub { targets: Counter::new(targets), phantom: ::std::marker::PhantomData };
         let produced = ingress.targets.produced().clone();
 
         let input = scope.subgraph.borrow_mut().new_input(produced);
@@ -107,7 +109,7 @@ pub trait Leave<G: Scope, D: Data> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9).to_stream(outer);
-    ///     let output = outer.scoped::<u32,_,_>(|inner| {
+    ///     let output = outer.scoped::<u64,_,_>(|inner| {
     ///         stream.enter(inner).leave()
     ///     });
     /// });
@@ -115,7 +117,7 @@ pub trait Leave<G: Scope, D: Data> {
     fn leave(&self) -> Stream<G, D>;
 }
 
-impl<'a, G: Scope, D: Data, T: Timestamp> Leave<G, D> for Stream<Child<'a, G, T>, D> {
+impl<'a, G: Scope, D: Data, T: Timestamp+Refines<G::Timestamp>> Leave<G, D> for Stream<Child<'a, G, T>, D> {
     fn leave(&self) -> Stream<G, D> {
 
         let scope = self.scope();
@@ -134,16 +136,17 @@ impl<'a, G: Scope, D: Data, T: Timestamp> Leave<G, D> for Stream<Child<'a, G, T>
 }
 
 
-struct IngressNub<TOuter: Timestamp, TInner: Timestamp, TData: Data> {
-    targets: Counter<Product<TOuter, TInner>, TData, Tee<Product<TOuter, TInner>, TData>>,
+struct IngressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data> {
+    targets: Counter<TInner, TData, Tee<TInner, TData>>,
+    phantom: ::std::marker::PhantomData<TOuter>,
 }
 
-impl<TOuter: Timestamp, TInner: Timestamp, TData: Data> Push<Bundle<TOuter, TData>> for IngressNub<TOuter, TInner, TData> {
+impl<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data> Push<Bundle<TOuter, TData>> for IngressNub<TOuter, TInner, TData> {
     fn push(&mut self, message: &mut Option<Bundle<TOuter, TData>>) {
         if let Some(message) = message {
             let outer_message = message.as_mut();
             let data = ::std::mem::replace(&mut outer_message.data, Vec::new());
-            let mut inner_message = Some(Bundle::from_typed(Message::new(Product::new(outer_message.time.clone(), Default::default()), data, 0, 0)));
+            let mut inner_message = Some(Bundle::from_typed(Message::new(TInner::to_inner(outer_message.time.clone()), data, 0, 0)));
             self.targets.push(&mut inner_message);
             if let Some(inner_message) = inner_message {
                 if let Some(inner_message) = inner_message.if_typed() {
@@ -156,18 +159,18 @@ impl<TOuter: Timestamp, TInner: Timestamp, TData: Data> Push<Bundle<TOuter, TDat
 }
 
 
-struct EgressNub<TOuter: Timestamp, TInner: Timestamp, TData: Data> {
+struct EgressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data> {
     targets: Tee<TOuter, TData>,
     phantom: PhantomData<TInner>,
 }
 
-impl<TOuter, TInner, TData> Push<Bundle<Product<TOuter, TInner>, TData>> for EgressNub<TOuter, TInner, TData>
-where TOuter: Timestamp, TInner: Timestamp, TData: Data {
-    fn push(&mut self, message: &mut Option<Bundle<Product<TOuter, TInner>, TData>>) {
+impl<TOuter, TInner, TData> Push<Bundle<TInner, TData>> for EgressNub<TOuter, TInner, TData>
+where TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data {
+    fn push(&mut self, message: &mut Option<Bundle<TInner, TData>>) {
         if let Some(message) = message {
             let inner_message = message.as_mut();
             let data = ::std::mem::replace(&mut inner_message.data, Vec::new());
-            let mut outer_message = Some(Bundle::from_typed(Message::new(inner_message.time.outer.clone(), data, 0, 0)));
+            let mut outer_message = Some(Bundle::from_typed(Message::new(inner_message.time.clone().to_outer(), data, 0, 0)));
             self.targets.push(&mut outer_message);
             if let Some(outer_message) = outer_message {
                 if let Some(outer_message) = outer_message.if_typed() {

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -24,7 +24,8 @@
 use std::marker::PhantomData;
 
 use progress::Timestamp;
-use progress::nested::{Refines, Source, Target};
+use progress::timestamp::Refines;
+use progress::nested::{Source, Target};
 use progress::nested::product::Product;
 use Data;
 use communication::Push;

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -35,7 +35,7 @@ pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
     ///
     /// timely::example(|scope| {
-    ///     scope.scoped(|scope| {
+    ///     scope.scoped("Loop", |scope| {
     ///         // circulate 0..10 for 100 iterations.
     ///         let (handle, cycle) = scope.loop_variable(100, 1);
     ///         (0..10).to_stream(scope)
@@ -112,7 +112,7 @@ pub trait ConnectLoop<G: ScopeParent, T: Timestamp, D: Data> {
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
     ///
     /// timely::example(|scope| {
-    ///     scope.scoped(|scope| {
+    ///     scope.scoped("Loop", |scope| {
     ///         // circulate 0..10 for 100 iterations.
     ///         let (handle, cycle) = scope.loop_variable(100, 1);
     ///         (0..10).to_stream(scope)

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -19,7 +19,7 @@ use dataflow::channels::pushers::{Counter, Tee};
 use worker::AsWorker;
 
 use dataflow::{Stream, Scope, ScopeParent};
-use dataflow::scopes::child::Iterative as Child;
+use dataflow::scopes::child::Iterative;
 
 /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
 pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
@@ -45,11 +45,11 @@ pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
     ///     });
     /// });
     /// ```
-    fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Child<'a, G, T>, D>);
+    fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Iterative<'a, G, T>, D>);
 }
 
-impl<'a, G: ScopeParent, T: Timestamp> LoopVariable<'a, G, T> for Child<'a, G, T> {
-    fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Child<'a, G, T>, D>) {
+impl<'a, G: ScopeParent, T: Timestamp> LoopVariable<'a, G, T> for Iterative<'a, G, T> {
+    fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Iterative<'a, G, T>, D>) {
 
         let (targets, registrar) = Tee::<Product<G::Timestamp, T>, D>::new();
 
@@ -125,7 +125,7 @@ pub trait ConnectLoop<G: ScopeParent, T: Timestamp, D: Data> {
     fn connect_loop(&self, Handle<G::Timestamp, T, D>);
 }
 
-impl<'a, G: ScopeParent, T: Timestamp, D: Data> ConnectLoop<G, T, D> for Stream<Child<'a, G, T>, D> {
+impl<'a, G: ScopeParent, T: Timestamp, D: Data> ConnectLoop<G, T, D> for Stream<Iterative<'a, G, T>, D> {
     fn connect_loop(&self, helper: Handle<G::Timestamp, T, D>) {
         let channel_id = self.scope().new_identifier();
         self.connect_to(Target { index: helper.index, port: 0 }, helper.target, channel_id);

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -19,7 +19,7 @@ use dataflow::channels::pushers::{Counter, Tee};
 use worker::AsWorker;
 
 use dataflow::{Stream, Scope, ScopeParent};
-use dataflow::scopes::Child;
+use dataflow::scopes::child::Iterative as Child;
 
 /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
 pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
@@ -31,15 +31,18 @@ pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
     ///
     /// # Examples
     /// ```
+    /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
     ///
     /// timely::example(|scope| {
-    ///     // circulate 0..10 for 100 iterations.
-    ///     let (handle, cycle) = scope.loop_variable(100, 1);
-    ///     (0..10).to_stream(scope)
-    ///            .concat(&cycle)
-    ///            .inspect(|x| println!("seen: {:?}", x))
-    ///            .connect_loop(handle);
+    ///     scope.scoped(|scope| {
+    ///         // circulate 0..10 for 100 iterations.
+    ///         let (handle, cycle) = scope.loop_variable(100, 1);
+    ///         (0..10).to_stream(scope)
+    ///                .concat(&cycle)
+    ///                .inspect(|x| println!("seen: {:?}", x))
+    ///                .connect_loop(handle);
+    ///     });
     /// });
     /// ```
     fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Child<'a, G, T>, D>);
@@ -105,15 +108,18 @@ pub trait ConnectLoop<G: ScopeParent, T: Timestamp, D: Data> {
     ///
     /// # Examples
     /// ```
+    /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
     ///
     /// timely::example(|scope| {
-    ///     // circulate 0..10 for 100 iterations.
-    ///     let (handle, cycle) = scope.loop_variable(100, 1);
-    ///     (0..10).to_stream(scope)
-    ///            .concat(&cycle)
-    ///            .inspect(|x| println!("seen: {:?}", x))
-    ///            .connect_loop(handle);
+    ///     scope.scoped(|scope| {
+    ///         // circulate 0..10 for 100 iterations.
+    ///         let (handle, cycle) = scope.loop_variable(100, 1);
+    ///         (0..10).to_stream(scope)
+    ///                .concat(&cycle)
+    ///                .inspect(|x| println!("seen: {:?}", x))
+    ///                .connect_loop(handle);
+    ///     });
     /// });
     /// ```
     fn connect_loop(&self, Handle<G::Timestamp, T, D>);

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -12,7 +12,7 @@ use progress::nested::{Source, Target};
 use progress::ChangeBatch;
 
 use progress::nested::product::Product;
-use progress::nested::Summary::Local;
+// use progress::nested::Summary::Local;
 
 use dataflow::channels::Bundle;
 use dataflow::channels::pushers::{Counter, Tee};
@@ -64,7 +64,7 @@ impl<'a, G: ScopeParent, T: Timestamp> LoopVariable<'a, G, T> for Child<'a, G, T
         let index = self.add_operator(Box::new(Operator {
             consumed_messages:  consumed,
             produced_messages:  produced,
-            summary:            Local(summary),
+            summary:            Product::new(Default::default(), summary),
         }));
 
         let helper = Handle {

--- a/src/dataflow/operators/flow_controlled.rs
+++ b/src/dataflow/operators/flow_controlled.rs
@@ -35,19 +35,17 @@ pub struct IteratorSourceInput<T: Clone, D: Data, DI: IntoIterator<Item=D>, I: I
 /// # Example
 /// ```rust
 /// extern crate timely;
-/// 
+///
 /// use timely::dataflow::operators::flow_controlled::{iterator_source, IteratorSourceInput};
 /// use timely::dataflow::operators::{probe, Probe, Inspect};
-/// 
-/// use timely::progress::timestamp::RootTimestamp;
-/// 
+///
 /// fn main() {
 ///     timely::execute_from_args(std::env::args(), |worker| {
 ///         let mut input = (0u64..100000).peekable();
 ///         worker.dataflow(|scope| {
 ///             let mut probe_handle = probe::Handle::new();
 ///             let probe_handle_2 = probe_handle.clone();
-/// 
+///
 ///             let mut next_t: u64 = 0;
 ///             iterator_source(
 ///                 scope,
@@ -58,7 +56,7 @@ pub struct IteratorSourceInput<T: Clone, D: Data, DI: IntoIterator<Item=D>, I: I
 ///                         Some(IteratorSourceInput {
 ///                             lower_bound: Default::default(),
 ///                             data: vec![
-///                                 (RootTimestamp::new(next_t),
+///                                 (next_t,
 ///                                  input.by_ref().take(10).map(|x| (/* "timestamp" */ x, x)).collect::<Vec<_>>())],
 ///                             target: *prev_t,
 ///                         })

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -200,9 +200,9 @@ impl<'a, T: Timestamp, D, P: Push<Bundle<T, D>>> OutputHandle<'a, T, D, P> {
     ///     (0..10).to_stream(scope)
     ///            .unary(Pipeline, "example", |_cap, _info| |input, output| {
     ///                input.for_each(|cap, data| {
-    ///                    let mut time = cap.time().clone();
-    ///                    time.inner += 1;
-    ///                    output.session(&cap.delayed(&time)).give_vec(&mut data.replace(Vec::new()));
+    ///                    let time = cap.time().clone() + 1;
+    ///                    output.session(&cap.delayed(&time))
+    ///                          .give_vec(&mut data.replace(Vec::new()));
     ///                });
     ///            });
     /// });

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -59,8 +59,7 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     ///            .unary_notify(Pipeline, "example", Vec::new(), |input, output, notificator| {
     ///                input.for_each(|cap, data| {
     ///                    output.session(&cap).give_vec(&mut data.replace(Vec::new()));
-    ///                    let mut time = cap.time().clone();
-    ///                    time.inner += 1;
+    ///                    let time = cap.time().clone() + 1;
     ///                    notificator.notify_at(cap.delayed(&time));
     ///                });
     ///                notificator.for_each(|cap,_,_| {
@@ -191,7 +190,7 @@ fn notificator_delivers_notifications_in_topo_order() {
 /// use timely::dataflow::channels::pact::Pipeline;
 ///
 /// timely::execute(timely::Configuration::Thread, |worker| {
-///     let (mut in1, mut in2) = worker.dataflow(|scope| {
+///     let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
 ///         let (in1_handle, in1) = scope.new_input();
 ///         let (in2_handle, in2) = scope.new_input();
 ///         in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
@@ -272,8 +271,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                move |input, output| {
     ///                    input.for_each(|cap, data| {
     ///                        output.session(&cap).give_vec(&mut data.replace(Vec::new()));
-    ///                        let mut time = cap.time().clone();
-    ///                        time.inner += 1;
+    ///                        let time = cap.time().clone() + 1;
     ///                        notificator.notify_at(cap.delayed(&time));
     ///                    });
     ///                    notificator.for_each(&[input.frontier()], |cap, _| {
@@ -389,8 +387,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                move |input, output| {
     ///                    input.for_each(|cap, data| {
     ///                        output.session(&cap).give_vec(&mut data.replace(Vec::new()));
-    ///                        let mut time = cap.time().clone();
-    ///                        time.inner += 1;
+    ///                        let time = cap.time().clone() + 1;
     ///                        notificator.notify_at(cap.delayed(&time));
     ///                        assert_eq!(notificator.pending().filter(|t| t.0.time() == &time).count(), 1);
     ///                    });

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -306,7 +306,6 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     /// use timely::dataflow::Scope;
     ///
     /// timely::example(|scope| {

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -27,13 +27,12 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
     /// use timely::dataflow::operators::generic::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// fn main() {
     ///     timely::example(|scope| {
     ///         (0u64..10).to_stream(scope)
     ///             .unary_frontier(Pipeline, "example", |default_cap, _info| {
-    ///                 let mut cap = Some(default_cap.delayed(&RootTimestamp::new(12)));
+    ///                 let mut cap = Some(default_cap.delayed(&12));
     ///                 let mut notificator = FrontierNotificator::new();
     ///                 let mut stash = HashMap::new();
     ///                 let mut vector = Vec::new();
@@ -75,12 +74,12 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
     /// use timely::dataflow::operators::generic::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// fn main() {
     ///     timely::example(|scope| {
     ///         let mut vector = Vec::new();
-    ///         (0u64..10).to_stream(scope)
+    ///         (0u64..10)
+    ///             .to_stream(scope)
     ///             .unary_notify(Pipeline, "example", None, move |input, output, notificator| {
     ///                 input.for_each(|time, data| {
     ///                     data.swap(&mut vector);
@@ -110,13 +109,12 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::{ToStream, FrontierNotificator};
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     /// use timely::dataflow::Scope;
     ///
     /// timely::example(|scope| {
     ///     (0u64..10).to_stream(scope)
     ///         .unary(Pipeline, "example", |default_cap, _info| {
-    ///             let mut cap = Some(default_cap.delayed(&RootTimestamp::new(12)));
+    ///             let mut cap = Some(default_cap.delayed(&12));
     ///             let mut vector = Vec::new();
     ///             move |input, output| {
     ///                 if let Some(ref c) = cap.take() {
@@ -150,7 +148,7 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::execute(timely::Configuration::Thread, |worker| {
-    ///    let (mut in1, mut in2) = worker.dataflow(|scope| {
+    ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();
     ///        in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
@@ -211,7 +209,7 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
     /// timely::execute(timely::Configuration::Thread, |worker| {
-    ///    let (mut in1, mut in2) = worker.dataflow(|scope| {
+    ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();
     ///
@@ -263,14 +261,13 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::{ToStream, Inspect, FrontierNotificator};
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
-    /// use timely::progress::timestamp::RootTimestamp;
     /// use timely::dataflow::Scope;
     ///
     /// timely::example(|scope| {
     ///     let stream2 = (0u64..10).to_stream(scope);
     ///     (0u64..10).to_stream(scope)
     ///         .binary(&stream2, Pipeline, Pipeline, "example", |default_cap, _info| {
-    ///             let mut cap = Some(default_cap.delayed(&RootTimestamp::new(12)));
+    ///             let mut cap = Some(default_cap.delayed(&12));
     ///             let mut vector1 = Vec::new();
     ///             let mut vector2 = Vec::new();
     ///             move |input1, input2, output| {
@@ -548,14 +545,13 @@ impl<G: Scope, D1: Data> Operator<G, D1> for Stream<G, D1> {
 ///             let mut done = false;
 ///             if let Some(cap) = cap.as_mut() {
 ///                 // get some data and send it.
-///                 let mut time = cap.time().clone();
+///                 let time = cap.time().clone();
 ///                 output.session(&cap)
-///                       .give(cap.time().inner);
+///                       .give(*cap.time());
 ///
 ///                 // downgrade capability.
-///                 time.inner += 1;
-///                 *cap = cap.delayed(&time);
-///                 done = time.inner > 20;
+///                 cap.downgrade(&(time + 1));
+///                 done = time > 20;
 ///             }
 ///
 ///             if done { cap = None; }

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -7,13 +7,11 @@ use std::default::Default;
 use progress::frontier::Antichain;
 use progress::{Operate, Timestamp, ChangeBatch};
 use progress::nested::Source;
-// use progress::timestamp::RootTimestamp;
 
 use Data;
 use communication::Push;
 use dataflow::{Stream, ScopeParent, Scope};
 use dataflow::channels::{Message, pushers::{Tee, Counter}};
-// use worker::Worker;
 
 // TODO : This is an exogenous input, but it would be nice to wrap a Subgraph in something
 // TODO : more like a harness, with direct access to its inputs.

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -6,14 +6,14 @@ use std::default::Default;
 
 use progress::frontier::Antichain;
 use progress::{Operate, Timestamp, ChangeBatch};
-use progress::nested::{subgraph::Source, product::Product};
-use progress::timestamp::RootTimestamp;
+use progress::nested::Source;
+// use progress::timestamp::RootTimestamp;
 
 use Data;
-use communication::{Allocate, Push};
-use dataflow::{Stream, Scope, scopes::Child};
+use communication::Push;
+use dataflow::{Stream, ScopeParent, Scope};
 use dataflow::channels::{Message, pushers::{Tee, Counter}};
-use worker::Worker;
+// use worker::Worker;
 
 // TODO : This is an exogenous input, but it would be nice to wrap a Subgraph in something
 // TODO : more like a harness, with direct access to its inputs.
@@ -23,7 +23,7 @@ use worker::Worker;
 // NOTE : Might be able to fix with another lifetime parameter, say 'c: 'a.
 
 /// Create a new `Stream` and `Handle` through which to supply input.
-pub trait Input<'a, A: Allocate, T: Timestamp> {
+pub trait Input : Scope {
     /// Create a new `Stream` and `Handle` through which to supply input.
     ///
     /// The `new_input` method returns a pair `(Handle, Stream)` where the `Stream` can be used
@@ -57,7 +57,7 @@ pub trait Input<'a, A: Allocate, T: Timestamp> {
     ///     }
     /// });
     /// ```
-    fn new_input<D: Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Worker<A>, T>, D>);
+    fn new_input<D: Data>(&mut self) -> (Handle<<Self as ScopeParent>::Timestamp, D>, Stream<Self, D>);
 
     /// Create a new stream from a supplied interactive handle.
     ///
@@ -89,19 +89,20 @@ pub trait Input<'a, A: Allocate, T: Timestamp> {
     ///     }
     /// });
     /// ```
-    fn input_from<D: Data>(&mut self, handle: &mut Handle<T, D>) -> Stream<Child<'a, Worker<A>, T>, D>;
+    fn input_from<D: Data>(&mut self, handle: &mut Handle<<Self as ScopeParent>::Timestamp, D>) -> Stream<Self, D>;
 }
 
-impl<'a, A: Allocate, T: Timestamp> Input<'a, A, T> for Child<'a, Worker<A>, T> {
-    fn new_input<D: Data>(&mut self) -> (Handle<T, D>, Stream<Child<'a, Worker<A>, T>, D>) {
+use order::TotalOrder;
+impl<G: Scope> Input for G where <G as ScopeParent>::Timestamp: TotalOrder {
+    fn new_input<D: Data>(&mut self) -> (Handle<<G as ScopeParent>::Timestamp, D>, Stream<G, D>) {
         let mut handle = Handle::new();
         let stream = self.input_from(&mut handle);
         (handle, stream)
     }
 
-    fn input_from<D: Data>(&mut self, handle: &mut Handle<T, D>) -> Stream<Child<'a, Worker<A>, T>, D> {
+    fn input_from<D: Data>(&mut self, handle: &mut Handle<<G as ScopeParent>::Timestamp, D>) -> Stream<G, D> {
 
-        let (output, registrar) = Tee::<Product<RootTimestamp, T>, D>::new();
+        let (output, registrar) = Tee::<<G as ScopeParent>::Timestamp, D>::new();
         let counter = Counter::new(output);
         let produced = counter.produced().clone();
 
@@ -122,26 +123,26 @@ impl<'a, A: Allocate, T: Timestamp> Input<'a, A, T> for Child<'a, Worker<A>, T> 
 }
 
 struct Operator<T:Timestamp> {
-    progress:   Rc<RefCell<ChangeBatch<Product<RootTimestamp, T>>>>,           // times closed since last asked
-    messages:   Rc<RefCell<ChangeBatch<Product<RootTimestamp, T>>>>,           // messages sent since last asked
+    progress:   Rc<RefCell<ChangeBatch<T>>>,           // times closed since last asked
+    messages:   Rc<RefCell<ChangeBatch<T>>>,           // messages sent since last asked
     copies:     usize,
 }
 
-impl<T:Timestamp> Operate<Product<RootTimestamp, T>> for Operator<T> {
+impl<T:Timestamp> Operate<T> for Operator<T> {
     fn name(&self) -> String { "Input".to_owned() }
     fn inputs(&self) -> usize { 0 }
     fn outputs(&self) -> usize { 1 }
 
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<<Product<RootTimestamp, T> as Timestamp>::Summary>>>,
-                                           Vec<ChangeBatch<Product<RootTimestamp, T>>>) {
+    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<<T as Timestamp>::Summary>>>,
+                                           Vec<ChangeBatch<T>>) {
         let mut map = ChangeBatch::new();
         map.update(Default::default(), self.copies as i64);
         (Vec::new(), vec![map])
     }
 
-    fn pull_internal_progress(&mut self,_messages_consumed: &mut [ChangeBatch<Product<RootTimestamp, T>>],
-                                         frontier_progress: &mut [ChangeBatch<Product<RootTimestamp, T>>],
-                                         messages_produced: &mut [ChangeBatch<Product<RootTimestamp, T>>]) -> bool
+    fn pull_internal_progress(&mut self,_messages_consumed: &mut [ChangeBatch<T>],
+                                         frontier_progress: &mut [ChangeBatch<T>],
+                                         messages_produced: &mut [ChangeBatch<T>]) -> bool
     {
         self.messages.borrow_mut().drain_into(&mut messages_produced[0]);
         self.progress.borrow_mut().drain_into(&mut frontier_progress[0]);
@@ -154,11 +155,11 @@ impl<T:Timestamp> Operate<Product<RootTimestamp, T>> for Operator<T> {
 
 /// A handle to an input `Stream`, used to introduce data to a timely dataflow computation.
 pub struct Handle<T: Timestamp, D: Data> {
-    progress: Vec<Rc<RefCell<ChangeBatch<Product<RootTimestamp, T>>>>>,
-    pushers: Vec<Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>>,
+    progress: Vec<Rc<RefCell<ChangeBatch<T>>>>,
+    pushers: Vec<Counter<T, D, Tee<T, D>>>,
     buffer1: Vec<D>,
     buffer2: Vec<D>,
-    now_at: Product<RootTimestamp, T>,
+    now_at: T,
 }
 
 impl<T:Timestamp, D: Data> Handle<T, D> {
@@ -225,15 +226,18 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     ///     }
     /// });
     /// ```
-    pub fn to_stream<'a, A: Allocate>(&mut self, scope: &mut Child<'a, Worker<A>, T>) -> Stream<Child<'a, Worker<A>, T>, D>
-    where T: Ord {
+    pub fn to_stream<G: Scope>(&mut self, scope: &mut G) -> Stream<G, D>
+    where
+        T: TotalOrder,
+        G: ScopeParent<Timestamp=T>,
+    {
         scope.input_from(self)
     }
 
     fn register(
         &mut self,
-        pusher: Counter<Product<RootTimestamp, T>, D, Tee<Product<RootTimestamp, T>, D>>,
-        progress: Rc<RefCell<ChangeBatch<Product<RootTimestamp, T>>>>
+        pusher: Counter<T, D, Tee<T, D>>,
+        progress: Rc<RefCell<ChangeBatch<T>>>
     ) {
         // flush current contents, so new registrant does not see existing data.
         if !self.buffer1.is_empty() { self.flush(); }
@@ -316,11 +320,11 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// that this input can no longer produce data at earlier timestamps.
     pub fn advance_to(&mut self, next: T) {
         // Assert that we do not rewind time.
-        assert!(self.now_at.inner.less_equal(&next));
+        assert!(self.now_at.less_equal(&next));
         // Flush buffers if time has actually changed.
-        if !self.now_at.inner.eq(&next) {
+        if !self.now_at.eq(&next) {
             self.close_epoch();
-            self.now_at = RootTimestamp::new(next);
+            self.now_at = next;
             for progress in self.progress.iter() {
                 progress.borrow_mut().update(self.now_at.clone(), 1);
             }
@@ -335,11 +339,11 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
 
     /// Reports the current epoch.
     pub fn epoch(&self) -> &T {
-        &self.now_at.inner
+        &self.now_at
     }
 
     /// Reports the current timestamp.
-    pub fn time(&self) -> &Product<RootTimestamp, T> {
+    pub fn time(&self) -> &T {
         &self.now_at
     }
 }

--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -182,7 +182,7 @@ impl<T: Timestamp> Clone for Handle<T> {
 mod tests {
 
     use ::communication::Configuration;
-    use ::progress::timestamp::RootTimestamp;
+    // use ::progress::timestamp::RootTimestamp;
     use dataflow::operators::{Input, Probe};
 
     #[test]
@@ -200,9 +200,9 @@ mod tests {
             // introduce data and watch!
             for round in 0..10 {
                 assert!(!probe.done());
-                assert!(probe.less_equal(&RootTimestamp::new(round)));
+                assert!(probe.less_equal(&round));
                 // assert!(!probe.less_than(&RootTimestamp::new(round)));
-                assert!(probe.less_than(&RootTimestamp::new(round + 1)));
+                assert!(probe.less_than(&(round + 1)));
                 input.advance_to(round + 1);
                 worker.step();
             }

--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -24,7 +24,6 @@ pub trait Probe<G: Scope, D: Data> {
     /// use timely::*;
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Input, Probe, Inspect};
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// // construct and execute a timely dataflow
     /// timely::execute(Configuration::Thread, |worker| {
@@ -55,7 +54,6 @@ pub trait Probe<G: Scope, D: Data> {
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Input, Probe, Inspect};
     /// use timely::dataflow::operators::probe::Handle;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// // construct and execute a timely dataflow
     /// timely::execute(Configuration::Thread, |worker| {
@@ -182,7 +180,6 @@ impl<T: Timestamp> Clone for Handle<T> {
 mod tests {
 
     use ::communication::Configuration;
-    // use ::progress::timestamp::RootTimestamp;
     use dataflow::operators::{Input, Probe};
 
     #[test]
@@ -201,7 +198,6 @@ mod tests {
             for round in 0..10 {
                 assert!(!probe.done());
                 assert!(probe.less_equal(&round));
-                // assert!(!probe.less_than(&RootTimestamp::new(round)));
                 assert!(probe.less_than(&(round + 1)));
                 input.advance_to(round + 1);
                 worker.step();

--- a/src/dataflow/operators/reclock.rs
+++ b/src/dataflow/operators/reclock.rs
@@ -21,18 +21,17 @@ pub trait Reclock<S: Scope, D: Data> {
     /// ```
     /// use timely::dataflow::operators::{ToStream, Delay, Map, Reclock, Capture};
     /// use timely::dataflow::operators::capture::Extract;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// let captured = timely::example(|scope| {
     ///
     ///     // produce data 0..10 at times 0..10.
     ///     let data = (0..10).to_stream(scope)
-    ///                       .delay(|x,t| RootTimestamp::new(*x));
+    ///                       .delay(|x,t| *x);
     ///
     ///     // product clock ticks at three times.
     ///     let clock = vec![3, 5, 8].into_iter()
     ///                              .to_stream(scope)
-    ///                              .delay(|x,t| RootTimestamp::new(*x))
+    ///                              .delay(|x,t| *x)
     ///                              .map(|_| ());
     ///
     ///     // reclock the data.
@@ -42,9 +41,9 @@ pub trait Reclock<S: Scope, D: Data> {
     ///
     /// let extracted = captured.extract();
     /// assert_eq!(extracted.len(), 3);
-    /// assert_eq!(extracted[0], (RootTimestamp::new(3), vec![0,1,2,3]));
-    /// assert_eq!(extracted[1], (RootTimestamp::new(5), vec![4,5]));
-    /// assert_eq!(extracted[2], (RootTimestamp::new(8), vec![6,7,8]));
+    /// assert_eq!(extracted[0], (3, vec![0,1,2,3]));
+    /// assert_eq!(extracted[1], (5, vec![4,5]));
+    /// assert_eq!(extracted[2], (8, vec![6,7,8]));
     /// ```
     fn reclock(&self, clock: &Stream<S, ()>) -> Stream<S, D>;
 }

--- a/src/dataflow/operators/unordered_input.rs
+++ b/src/dataflow/operators/unordered_input.rs
@@ -43,7 +43,6 @@ pub trait UnorderedInput<G: Scope> {
     /// use timely::dataflow::operators::*;
     /// use timely::dataflow::operators::capture::Extract;
     /// use timely::dataflow::Stream;
-    /// use timely::progress::timestamp::RootTimestamp;
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
@@ -55,7 +54,7 @@ pub trait UnorderedInput<G: Scope> {
     ///     let send = send.lock().unwrap().clone();
     ///
     ///     // create and capture the unordered input.
-    ///     let (mut input, mut cap) = worker.dataflow(|scope| {
+    ///     let (mut input, mut cap) = worker.dataflow::<usize,_,_>(|scope| {
     ///         let (input, stream) = scope.new_unordered_input();
     ///         stream.capture_into(send);
     ///         input
@@ -64,14 +63,14 @@ pub trait UnorderedInput<G: Scope> {
     ///     // feed values 0..10 at times 0..10.
     ///     for round in 0..10 {
     ///         input.session(cap.clone()).give(round);
-    ///         cap = cap.delayed(&RootTimestamp::new(round + 1));
+    ///         cap = cap.delayed(&(round + 1));
     ///         worker.step();
     ///     }
     /// }).unwrap();
     ///
     /// let extract = recv.extract();
     /// for i in 0..10 {
-    ///     assert_eq!(extract[i], (RootTimestamp::new(i), vec![i]));
+    ///     assert_eq!(extract[i], (i, vec![i]));
     /// }
     /// ```
     fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, Capability<G::Timestamp>), Stream<G, D>);

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -15,7 +15,7 @@ use super::{ScopeParent, Scope};
 /// of `Operate`s to a subgraph, and the connection of edges between them.
 pub struct Child<'a, G: ScopeParent, T: Timestamp> {
     /// The subgraph under assembly.
-    pub subgraph: &'a RefCell<SubgraphBuilder<G::Timestamp, T>>,
+    pub subgraph: &'a RefCell<SubgraphBuilder<G::Timestamp, Product<G::Timestamp, T>>>,
     /// A copy of the child's parent scope.
     pub parent:   G,
     /// The log writer for this scope.
@@ -64,7 +64,7 @@ impl<'a, G: ScopeParent, T: Timestamp> Scope for Child<'a, G, T> {
         let index = self.subgraph.borrow_mut().allocate_child_id();
         let path = self.subgraph.borrow().path.clone();
 
-        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone()));
+        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), "Subgraph"));
         let result = {
             let mut builder = Child {
                 subgraph: &subscope,
@@ -92,5 +92,11 @@ impl<'a, G: ScopeParent, T: Timestamp> Allocate for Child<'a, G, T> {
 }
 
 impl<'a, G: ScopeParent, T: Timestamp> Clone for Child<'a, G, T> {
-    fn clone(&self) -> Self { Child { subgraph: self.subgraph, parent: self.parent.clone(), logging: self.logging.clone() }}
+    fn clone(&self) -> Self {
+        Child {
+            subgraph: self.subgraph,
+            parent: self.parent.clone(),
+            logging: self.logging.clone()
+        }
+    }
 }

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -3,7 +3,8 @@
 use std::cell::RefCell;
 
 use progress::{Timestamp, Operate, SubgraphBuilder};
-use progress::nested::{Refines, Source, Target};
+use progress::nested::{Source, Target};
+use progress::timestamp::Refines;
 use progress::nested::product::Product;
 use communication::{Allocate, Data, Push, Pull};
 use logging::TimelyLogger as Logger;

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -78,14 +78,14 @@ where
     }
 
     #[inline]
-    fn scoped<T2: Timestamp, R, F: FnOnce(&mut Child<Self, T2>) -> R>(&mut self, func: F) -> R
+    fn scoped<T2: Timestamp, R, F: FnOnce(&mut Child<Self, T2>) -> R>(&mut self, name: &str, func: F) -> R
     where
         T2: Timestamp+Refines<T>,
     {
         let index = self.subgraph.borrow_mut().allocate_child_id();
         let path = self.subgraph.borrow().path.clone();
 
-        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), "Subgraph"));
+        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), name));
         let result = {
             let mut builder = Child {
                 subgraph: &subscope,

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -1,7 +1,7 @@
 //! Hierarchical organization of timely dataflow graphs.
 
 use progress::{Timestamp, Operate};
-use progress::nested::{Source, Target};
+use progress::nested::{Source, Target, Refines};
 // use logging::TimelyLogger as Logger;
 use communication::Allocate;
 use worker::AsWorker;
@@ -78,17 +78,18 @@ pub trait Scope: ScopeParent {
     /// ```
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Input, Enter, Leave};
+    /// use timely::progress::nested::product::Product;
     ///
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
     ///         let (input, stream) = child1.new_input::<String>();
-    ///         let output = child1.scoped::<u32,_,_>(|child2| {
+    ///         let output = child1.scoped::<Product<u64,u32>,_,_>(|child2| {
     ///             stream.enter(child2).leave()
     ///         });
     ///         input
     ///     });
     /// });
     /// ```
-    fn scoped<T: Timestamp, R, F:FnOnce(&mut Child<Self, T>)->R>(&mut self, func: F) -> R;
+    fn scoped<T: Timestamp, R, F:FnOnce(&mut Child<Self, T>)->R>(&mut self, func: F) -> R where T: Refines<<Self as ScopeParent>::Timestamp>;
 }

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -1,16 +1,14 @@
 //! Hierarchical organization of timely dataflow graphs.
 
 use progress::{Timestamp, Operate};
-use progress::nested::{Source, Target, Refines, product::Product};
-// use logging::TimelyLogger as Logger;
+use progress::nested::{Source, Target, product::Product};
+use progress::timestamp::Refines;
 use communication::Allocate;
 use worker::AsWorker;
 
-// pub mod root;
 pub mod child;
 
 pub use self::child::Child;
-// pub use self::root::Root;
 
 /// The information a child scope needs from its parent.
 pub trait ScopeParent: AsWorker+Clone {
@@ -19,7 +17,7 @@ pub trait ScopeParent: AsWorker+Clone {
 }
 
 impl<A: Allocate> ScopeParent for ::worker::Worker<A> {
-    type Timestamp = ::progress::timestamp::RootTimestamp;
+    type Timestamp = ();
 }
 
 
@@ -32,7 +30,7 @@ pub trait Scope: ScopeParent {
     /// A useful name describing the scope.
     fn name(&self) -> String;
 
-    /// A sequence of scope identifiers describing the path from the `Root` to this scope.
+    /// A sequence of scope identifiers describing the path from the worker root to this scope.
     fn addr(&self) -> Vec<usize>;
 
     /// Connects a source of data with a target of the data. This only links the two for

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -2,81 +2,9 @@
 
 pub use self::subgraph::{Subgraph, SubgraphBuilder};
 pub use self::subgraph::{Source, Target};
-// pub use self::summary::Summary;
 
 pub mod pointstamp_counter;
-// pub mod summary;
 pub mod product;
 pub mod subgraph;
-// pub mod subgraph_neu;
-
 pub mod reachability;
 pub mod reachability_neu;
-
-use super::Timestamp;
-
-/// Conversion between pointstamp types.
-///
-/// This trait is central to nested scopes, for which the inner timestamp must be
-/// related to the outer timestamp. These methods define those relationships.
-///
-/// It would be ideal to use Rust's From and Into traits, but they seem to be messed
-/// up due to coherence: we can't implement `Into` because it induces a from implementation
-/// we can't control.
-pub trait Refines<T: Timestamp> : Timestamp {
-    /// Converts the outer timestamp to an inner timestamp.
-    fn to_inner(other: T) -> Self;
-    /// Converts the inner timestamp to an outer timestamp.
-    fn to_outer(self) -> T;
-    /// Summarizes an inner path summary as an outer path summary.
-    ///
-    /// It is crucial for correctness that the result of this summarization's `results_in`
-    /// method is equivalent to `|time| path.results_in(time.to_inner()).to_outer()`, or
-    /// at least produces times less or equal to that result.
-    fn summarize(path: <Self as Timestamp>::Summary) -> <T as Timestamp>::Summary;
-}
-
-impl<T: Timestamp> Refines<T> for T {
-    fn to_inner(other: T) -> T { other }
-    fn to_outer(self) -> T { self }
-    fn summarize(path: <T as Timestamp>::Summary) -> <T as Timestamp>::Summary { path }
-}
-
-use progress::timestamp::{RootTimestamp, RootSummary};
-impl Refines<RootTimestamp> for usize {
-    fn to_inner(_: RootTimestamp) -> usize { Default::default() }
-    fn to_outer(self) -> RootTimestamp { RootTimestamp }
-    fn summarize(_: <usize as Timestamp>::Summary) -> RootSummary { RootSummary }
-}
-
-impl Refines<RootTimestamp> for u64 {
-    fn to_inner(_: RootTimestamp) -> u64 { Default::default() }
-    fn to_outer(self) -> RootTimestamp { RootTimestamp }
-    fn summarize(_: <u64 as Timestamp>::Summary) -> RootSummary { RootSummary }
-}
-
-impl Refines<RootTimestamp> for u32 {
-    fn to_inner(_: RootTimestamp) -> u32 { Default::default() }
-    fn to_outer(self) -> RootTimestamp { RootTimestamp }
-    fn summarize(_: <u32 as Timestamp>::Summary) -> RootSummary { RootSummary }
-}
-
-impl Refines<RootTimestamp> for i32 {
-    fn to_inner(_: RootTimestamp) -> i32 { Default::default() }
-    fn to_outer(self) -> RootTimestamp { RootTimestamp }
-    fn summarize(_: <i32 as Timestamp>::Summary) -> RootSummary { RootSummary }
-}
-
-impl Refines<RootTimestamp> for () {
-    fn to_inner(_: RootTimestamp) -> () { Default::default() }
-    fn to_outer(self) -> RootTimestamp { RootTimestamp }
-    fn summarize(_: <() as Timestamp>::Summary) -> RootSummary { RootSummary }
-}
-
-
-use std::time::Duration;
-impl Refines<RootTimestamp> for Duration {
-    fn to_inner(_: RootTimestamp) -> Duration { Default::default() }
-    fn to_outer(self) -> RootTimestamp { RootTimestamp }
-    fn summarize(_: <Duration as Timestamp>::Summary) -> RootSummary { RootSummary }
-}

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -8,6 +8,36 @@ pub mod pointstamp_counter;
 pub mod summary;
 pub mod product;
 pub mod subgraph;
+// pub mod subgraph_neu;
 
 pub mod reachability;
 pub mod reachability_neu;
+
+use super::Timestamp;
+
+/// Conversion between pointstamp types.
+///
+/// This trait is central to nested scopes, for which the inner timestamp must be
+/// related to the outer timestamp. These methods define those relationships.
+///
+/// It would be ideal to use Rust's From and Into traits, but they seem to be messed
+/// up due to coherence: we can't implement `Into` because it induces a from implementation
+/// we can't control.
+pub trait Refines<T: Timestamp> : Timestamp {
+    /// Converts the outer timestamp to an inner timestamp.
+    fn to_inner(other: T) -> Self;
+    /// Converts the inner timestamp to an outer timestamp.
+    fn to_outer(self) -> T;
+    /// Summarizes an inner path summary as an outer path summary.
+    ///
+    /// It is crucial for correctness that the result of this summarization's `results_in`
+    /// method is equivalent to `|time| path.results_in(time.to_inner()).to_outer()`, or
+    /// at least produces times less or equal to that result.
+    fn summarize(path: <Self as Timestamp>::Summary) -> <T as Timestamp>::Summary;
+}
+
+impl<T: Timestamp> Refines<T> for T {
+    fn to_inner(other: T) -> T { other }
+    fn to_outer(self) -> T { self }
+    fn summarize(path: <T as Timestamp>::Summary) -> <T as Timestamp>::Summary { path }
+}

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -41,3 +41,42 @@ impl<T: Timestamp> Refines<T> for T {
     fn to_outer(self) -> T { self }
     fn summarize(path: <T as Timestamp>::Summary) -> <T as Timestamp>::Summary { path }
 }
+
+use progress::timestamp::{RootTimestamp, RootSummary};
+impl Refines<RootTimestamp> for usize {
+    fn to_inner(_: RootTimestamp) -> usize { Default::default() }
+    fn to_outer(self) -> RootTimestamp { RootTimestamp }
+    fn summarize(_: <usize as Timestamp>::Summary) -> RootSummary { RootSummary }
+}
+
+impl Refines<RootTimestamp> for u64 {
+    fn to_inner(_: RootTimestamp) -> u64 { Default::default() }
+    fn to_outer(self) -> RootTimestamp { RootTimestamp }
+    fn summarize(_: <u64 as Timestamp>::Summary) -> RootSummary { RootSummary }
+}
+
+impl Refines<RootTimestamp> for u32 {
+    fn to_inner(_: RootTimestamp) -> u32 { Default::default() }
+    fn to_outer(self) -> RootTimestamp { RootTimestamp }
+    fn summarize(_: <u32 as Timestamp>::Summary) -> RootSummary { RootSummary }
+}
+
+impl Refines<RootTimestamp> for i32 {
+    fn to_inner(_: RootTimestamp) -> i32 { Default::default() }
+    fn to_outer(self) -> RootTimestamp { RootTimestamp }
+    fn summarize(_: <i32 as Timestamp>::Summary) -> RootSummary { RootSummary }
+}
+
+impl Refines<RootTimestamp> for () {
+    fn to_inner(_: RootTimestamp) -> () { Default::default() }
+    fn to_outer(self) -> RootTimestamp { RootTimestamp }
+    fn summarize(_: <() as Timestamp>::Summary) -> RootSummary { RootSummary }
+}
+
+
+use std::time::Duration;
+impl Refines<RootTimestamp> for Duration {
+    fn to_inner(_: RootTimestamp) -> Duration { Default::default() }
+    fn to_outer(self) -> RootTimestamp { RootTimestamp }
+    fn summarize(_: <Duration as Timestamp>::Summary) -> RootSummary { RootSummary }
+}

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -2,10 +2,10 @@
 
 pub use self::subgraph::{Subgraph, SubgraphBuilder};
 pub use self::subgraph::{Source, Target};
-pub use self::summary::Summary;
+// pub use self::summary::Summary;
 
 pub mod pointstamp_counter;
-pub mod summary;
+// pub mod summary;
 pub mod product;
 pub mod subgraph;
 // pub mod subgraph_neu;

--- a/src/progress/nested/product.rs
+++ b/src/progress/nested/product.rs
@@ -1,15 +1,13 @@
-//! A pair timestamp suitable for use with the product partial order.
+//! A product-order timestamp combinator
 
-// use std::cmp::Ordering;
 use std::fmt::{Formatter, Error, Debug};
 
 use ::order::{PartialOrder, TotalOrder};
 use progress::Timestamp;
-// use progress::nested::summary::Summary;
 
 use abomonation::Abomonation;
 
-use super::Refines;
+use progress::timestamp::Refines;
 
 impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
     fn to_inner(other: TOuter) -> Self {
@@ -20,11 +18,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, T
     }
     fn summarize(path: <Self as Timestamp>::Summary) -> <TOuter as Timestamp>::Summary {
         path.outer
-        // use progress::nested::summary::Summary;
-        // match path {
-        //     Summary::Local(_) => Default::default(),
-        //     Summary::Outer(y, _) => y,
-        // }
     }
 }
 
@@ -89,7 +82,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<Product<TOuter, TInner>> 
 }
 
 impl<TOuter: Abomonation, TInner: Abomonation> Abomonation for Product<TOuter, TInner> {
-    // unsafe fn embalm(&mut self) { self.outer.embalm(); self.inner.embalm(); }
     unsafe fn entomb<W: ::std::io::Write>(&self, write: &mut W) -> ::std::io::Result<()> {
         self.outer.entomb(write)?;
         self.inner.entomb(write)?;
@@ -109,9 +101,6 @@ impl<TOuter: Abomonation, TInner: Abomonation> Abomonation for Product<TOuter, T
 /// public traits for public types.
 pub trait Empty : PartialOrder { }
 
-use progress::timestamp::RootTimestamp;
-
-impl Empty for RootTimestamp { }
 impl Empty for () { }
 impl<T1: Empty, T2: Empty> Empty for Product<T1, T2> { }
 

--- a/src/progress/nested/product.rs
+++ b/src/progress/nested/product.rs
@@ -9,6 +9,25 @@ use progress::nested::summary::Summary;
 
 use abomonation::Abomonation;
 
+use super::Refines;
+
+impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
+    fn to_inner(other: TOuter) -> Self {
+        Product::new(other, Default::default())
+    }
+    fn to_outer(self: Product<TOuter, TInner>) -> TOuter {
+        self.outer
+    }
+    fn summarize(path: <Self as Timestamp>::Summary) -> <TOuter as Timestamp>::Summary {
+        use progress::nested::summary::Summary;
+        match path {
+            Summary::Local(_) => Default::default(),
+            Summary::Outer(y, _) => y,
+        }
+
+    }
+}
+
 /// A nested pair of timestamps, one outer and one inner.
 ///
 /// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrd`,

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -53,7 +53,7 @@ pub struct Target {
 /// actually creates a `Subgraph`.
 pub struct SubgraphBuilder<TOuter, TInner>
 where
-    TInner: Timestamp+Refines<TOuter>,
+    TInner: Timestamp,
     TOuter: Timestamp,
 {
     /// The name of this subgraph.

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -16,7 +16,8 @@ use progress::{Timestamp, Operate};
 
 use progress::ChangeBatch;
 use progress::broadcast::Progcaster;
-use progress::nested::{reachability, Refines};
+use progress::nested::reachability;
+use progress::timestamp::Refines;
 
 // IMPORTANT : by convention, a child identifier of zero is used to indicate inputs and outputs of
 // the Subgraph itself. An identifier greater than zero corresponds to an actual child, which can

--- a/src/progress/nested/summary.rs
+++ b/src/progress/nested/summary.rs
@@ -49,21 +49,6 @@ impl<S: PartialOrder, T: PartialOrder> PartialOrder for Summary<S, T> {
     }
 }
 
-// impl<S:PartialOrder+Copy, T:PartialOrder+Copy> PartialOrder for Summary<S, T> {
-//     #[inline]
-//     fn partial_cmp(&self, other: &Summary<S, T>) -> Option<Ordering> {
-//         // Two summaries are comparable if they are of the same type (Local, Outer).
-//         // Otherwise, as Local *updates* and Outer *sets* the inner coordinate, we
-//         // cannot be sure that either strictly improves on the other.
-//         match (*self, *other) {
-//             (Local(t1),    Local(t2))    => t1.partial_cmp(&t2),
-//             (Outer(s1,t1), Outer(s2,t2)) => (s1,t1).partial_cmp(&(s2,t2)),
-//             (Local(_),     Outer(_,_))   |
-//             (Outer(_,_),   Local(_))     => None,
-//         }
-//     }
-// }
-
 impl<TOuter, SOuter, TInner, SInner> PathSummary<Product<TOuter, TInner>> for Summary<SOuter, SInner>
 where TOuter: Timestamp,
       TInner: Timestamp,

--- a/src/synchronization/barrier.rs
+++ b/src/synchronization/barrier.rs
@@ -1,8 +1,8 @@
 //! Barrier synchronization.
 
 use ::communication::Allocate;
-use progress::timestamp::RootTimestamp;
-use progress::nested::product::Product;
+// use progress::timestamp::RootTimestamp;
+// use progress::nested::product::Product;
 use dataflow::{InputHandle, ProbeHandle};
 use worker::Worker;
 
@@ -10,7 +10,7 @@ use worker::Worker;
 pub struct Barrier<A: Allocate> {
     round: usize,
     input: InputHandle<usize, ()>,
-    probe: ProbeHandle<Product<RootTimestamp, usize>>,
+    probe: ProbeHandle<usize>,
     worker: Worker<A>,
 }
 

--- a/src/synchronization/barrier.rs
+++ b/src/synchronization/barrier.rs
@@ -1,8 +1,6 @@
 //! Barrier synchronization.
 
 use ::communication::Allocate;
-// use progress::timestamp::RootTimestamp;
-// use progress::nested::product::Product;
 use dataflow::{InputHandle, ProbeHandle};
 use worker::Worker;
 

--- a/src/synchronization/sequence.rs
+++ b/src/synchronization/sequence.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::time::Instant;
+use std::time::{Instant, Duration};
 use std::collections::VecDeque;
 
 use ::{communication::Allocate, ExchangeData};
@@ -35,7 +35,7 @@ impl<T: Ord+ExchangeData> Sequencer<T> {
         let recv_weak = Rc::downgrade(&recv);
 
         // build a dataflow used to serialize and circulate commands
-        worker.dataflow(move |dataflow| {
+        worker.dataflow::<Duration,_,_>(move |dataflow| {
 
             let peers = dataflow.peers();
             let mut recvd = Vec::new();
@@ -56,9 +56,7 @@ impl<T: Ord+ExchangeData> Sequencer<T> {
                         let capability = capability.as_mut().expect("Capability unavailable");
 
                         // downgrade capability to current time.
-                        let mut time = capability.time().clone();
-                        time.inner = timer.elapsed();
-                        capability.downgrade(&time);
+                        capability.downgrade(&timer.elapsed());
 
                         // drain and broadcast `send`.
                         let mut session = output.session(&capability);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,8 +5,7 @@ use std::cell::RefCell;
 use std::any::Any;
 use std::time::Instant;
 
-use progress::nested::Refines;
-use progress::timestamp::RootTimestamp;
+use progress::timestamp::{Refines};
 use progress::{Timestamp, Operate, SubgraphBuilder};
 use communication::{Allocate, Data, Push, Pull};
 use dataflow::scopes::Child;
@@ -107,7 +106,7 @@ impl<A: Allocate> Worker<A> {
     /// Construct a new dataflow.
     pub fn dataflow<T: Timestamp, R, F:FnOnce(&mut Child<Self, T>)->R>(&mut self, func: F) -> R
     where
-        T: Refines<RootTimestamp>
+        T: Refines<()>
     {
         self.dataflow_using(Box::new(()), |_, child| func(child))
     }
@@ -120,7 +119,7 @@ impl<A: Allocate> Worker<A> {
     /// for building the dataflow, and must be kept around until after the dataflow has completed operation.
     pub fn dataflow_using<T: Timestamp, R, F:FnOnce(&mut V, &mut Child<Self, T>)->R, V: Any+'static>(&mut self, mut resources: V, func: F) -> R
     where
-        T: Refines<RootTimestamp>,
+        T: Refines<()>,
     {
 
         let addr = vec![self.allocator.borrow().index()];
@@ -189,7 +188,7 @@ impl<A: Allocate> Clone for Worker<A> {
 
 struct Wrapper {
     _index: usize,
-    operate: Option<Box<Operate<RootTimestamp>>>,
+    operate: Option<Box<Operate<()>>>,
     resources: Option<Box<Any>>,
 }
 

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -1,13 +1,11 @@
 extern crate timely;
 extern crate timely_communication;
 
+use timely::Configuration;
+use timely::progress::nested::product::Product;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::progress::timestamp::RootTimestamp;
-
 use timely::dataflow::operators::{LoopVariable, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
-
-use timely_communication::Configuration;
 
 #[test] fn barrier_sync_1w() { barrier_sync_helper(Configuration::Thread); }
 #[test] fn barrier_sync_2w() { barrier_sync_helper(Configuration::Process(2)); }
@@ -21,7 +19,7 @@ fn barrier_sync_helper(config: ::timely_communication::Configuration) {
             stream.unary_notify(
                 Pipeline,
                 "Barrier",
-                vec![RootTimestamp::new(0), RootTimestamp::new(1)],
+                vec![Product::new((), 0), Product::new((), 1)],
                 move |_, _, notificator| {
                     let mut count = 0;
                     while let Some((cap, _count)) = notificator.next() {


### PR DESCRIPTION
This PR reworks subgraphs and subscopes a bit, with the aim of making things more flexible for subgraphs whose timestamps are not product-order structured. Potential examples include having the same timestamp as the containing scope (for creating regions for abstraction) and lexicographic-order structured extensions.

There is a new trait `Refines<T>` which is implementable by many timestamps, and which indicates how to convert into and from the refining timestamp, and how the refined path summaries can be abstracted.

```rust
    pub trait Refines<T: Timestamp> : Timestamp {
        /// Converts the outer timestamp to an inner timestamp.
        fn to_inner(other: T) -> Self;
        /// Converts the inner timestamp to an outer timestamp.
        fn to_outer(self) -> T;
        /// Summarizes an inner path summary as an outer path summary.
        ///
        /// It is crucial for correctness that the result of this summarization's `results_in`
        /// method is equivalent to `|time| path.results_in(time.to_inner()).to_outer()`, or
        /// at least produces times less or equal to that result.
        fn summarize(path: <Self as Timestamp>::Summary) -> <T as Timestamp>::Summary;
    }
```

This trait is *not* symmetric with `T` and `Self` because information is lost when we go from `Self` to `T`, and so we cannot expect that a path summary on `T` can be faithfully restored to a path summary on `Self`.

---

On possibly delightful consequence is that `RootTimestamp` is pretty useless now. Everything would refine it, and no one really wants to use `Product<RootTimestamp,T>` when they could just use `T`, so I got rid of it.

There is a little bit of fall-out with type inference. For some reason (more generics, I guess) inputs don't always drive type inference as well as the used to, and in some examples I had to explicitly annotate e.g. 

```rust
    worker.dataflow::<usize,_,_>( ... )
```

The reasons aren't especially clear, and they happen in some weird cases (e.g. not in examples/hello.rs, but yes in examples/distinct.rs apparently due to a hashmap).

---

A related change is essentially removing the complicated `PathSummary` implementation for `Product`. There was a bunch of `Outer` and `Local` stuff, and .. unfortunately I think it only makes sense if the *contained* scope is product ordered. That is, if you are an iterative scope, you want your *parent* scope to have this sort of summary.

Fortunately, it turns out that the weird structure hasn't been needed for a while, because nested scopes need not track the flow of their own internal capabilities out and back around to their inputs (the parent scope learns about them, and then presents them back as its input capabilities).