### PR TITLE
Reduce abomonation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - The `RootTimestamp` and `RootSummary` types have been excised. Where you previously used `Product<RootTimestamp,T>` you can now use `Product<(),T>`, or even better just `T`. The requirement of a worker's `dataflow()` method is that the timestamp type implement `Refines<()>`, which .. ideally would be true for all timestamps but we can't have a blanket implementation until specialization lands (I believe).
 
+- The communication crate now has a `bincode` feature flag which should swing serialization over to use serde's `Serialize` trait. While it seems to work the ergonomics are likely in flux, as the choice is crate-wide and doesn't allow you to pick and choose a la carte.
+
+
 ## 0.7.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ license = "MIT"
 
 #build = "booktests.rs"
 
+#[features]
+#bincode= ["communication/bincode"]
+
 [dependencies]
+serde = "1.0"
+serde_derive = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.3"
 timely_bytes = { path = "./bytes", version = "0.7" }

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -12,11 +12,13 @@ keywords = ["timely", "dataflow"]
 license = "MIT"
 
 [features]
-default=["arg_parse"]
-arg_parse=["getopts"]
+default = ["getopts"]
 
 [dependencies]
-getopts={version="0.2.14", optional=true}
+getopts = { version = "0.2.14", optional = true}
+bincode = { version = "1.0", optional = true }
+serde_derive = "1.0"
+serde = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.3"
 timely_bytes = { path = "../bytes", version = "0.7" }

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -1,9 +1,9 @@
 //! Initialization logic for a generic instance of the `Allocate` channel allocation trait.
 
 use std::thread;
-#[cfg(feature = "arg_parse")]
+#[cfg(feature = "getopts")]
 use std::io::BufRead;
-#[cfg(feature = "arg_parse")]
+#[cfg(feature = "getopts")]
 use getopts;
 use std::sync::Arc;
 
@@ -26,7 +26,7 @@ pub enum Configuration {
     Cluster(usize, usize, Vec<String>, bool, Box<Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>)
 }
 
-#[cfg(feature = "arg_parse")]
+#[cfg(feature = "getopts")]
 impl Configuration {
 
     /// Constructs a new configuration by parsing supplied text arguments.

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -75,8 +75,13 @@
 
 #![forbid(missing_docs)]
 
-#[cfg(feature = "arg_parse")]
+#[cfg(feature = "getopts")]
 extern crate getopts;
+#[cfg(feature = "bincode")]
+extern crate bincode;
+#[cfg(feature = "bincode")]
+extern crate serde;
+
 extern crate abomonation;
 #[macro_use] extern crate abomonation_derive;
 
@@ -91,6 +96,9 @@ pub mod message;
 
 use std::any::Any;
 
+#[cfg(feature = "bincode")]
+use serde::{Serialize, Deserialize};
+#[cfg(not(feature = "bincode"))]
 use abomonation::Abomonation;
 
 pub use allocator::Generic as Allocator;
@@ -99,8 +107,16 @@ pub use initialize::{initialize, initialize_from, Configuration, WorkerGuards};
 pub use message::Message;
 
 /// A composite trait for types that may be used with channels.
+#[cfg(not(feature = "bincode"))]
 pub trait Data : Send+Any+Abomonation+'static { }
+#[cfg(not(feature = "bincode"))]
 impl<T: Send+Any+Abomonation+'static> Data for T { }
+
+/// A composite trait for types that may be used with channels.
+#[cfg(feature = "bincode")]
+pub trait Data : Send+Any+Serialize+for<'a>Deserialize<'a>+'static { }
+#[cfg(feature = "bincode")]
+impl<T: Send+Any+Serialize+for<'a>Deserialize<'a>+'static> Data for T { }
 
 /// Pushing elements of type `T`.
 pub trait Push<T> {

--- a/src/dataflow/channels/mod.rs
+++ b/src/dataflow/channels/mod.rs
@@ -13,7 +13,7 @@ pub mod pact;
 pub type Bundle<T, D> = ::communication::Message<Message<T, D>>;
 
 /// A serializable representation of timestamped data.
-#[derive(Clone, Abomonation)]
+#[derive(Clone, Abomonation, Serialize, Deserialize)]
 pub struct Message<T, D> {
     /// The timestamp associated with the message.
     pub time: T,

--- a/src/dataflow/channels/pact.rs
+++ b/src/dataflow/channels/pact.rs
@@ -19,8 +19,6 @@ use super::{Bundle, Message};
 
 use logging::TimelyLogger as Logger;
 
-use abomonation::Abomonation;
-
 /// A `ParallelizationContract` allocates paired `Push` and `Pull` implementors.
 pub trait ParallelizationContract<T: 'static, D: 'static> {
     /// Type implementing `Push` produced by this pact.
@@ -57,7 +55,7 @@ impl<D, F: Fn(&D)->u64> Exchange<D, F> {
 }
 
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
-impl<T: Eq+Data+Abomonation+Clone, D: Data+Abomonation+Clone, F: Fn(&D)->u64+'static> ParallelizationContract<T, D> for Exchange<D, F> {
+impl<T: Eq+Data+Clone, D: Data+Clone, F: Fn(&D)->u64+'static> ParallelizationContract<T, D> for Exchange<D, F> {
     // TODO: The closure in the type prevents us from naming it.
     //       Could specialize `ExchangePusher` to a time-free version.
     type Pusher = Box<Push<Bundle<T, D>>>;
@@ -81,7 +79,7 @@ impl<T: Eq+Data+Abomonation+Clone, D: Data+Abomonation+Clone, F: Fn(&D)->u64+'st
 //     }
 // }
 
-// impl<T: Eq+Data+Abomonation+Clone, D: Data+Abomonation+Clone, F: Fn(&T, &D)->u64+'static> ParallelizationContract<T, D> for TimeExchange<D, T, F> {
+// impl<T: Eq+Data+Clone, D: Data+Clone, F: Fn(&T, &D)->u64+'static> ParallelizationContract<T, D> for TimeExchange<D, T, F> {
 //     type Pusher = ExchangePusher<T, D, Pusher<T, D, Box<Push<CommMessage<Message<T, D>>>>>, F>;
 //     type Puller = Puller<T, D, Box<Pull<CommMessage<Message<T, D>>>>>;
 //     fn connect<A: Allocate>(self, allocator: &mut A, identifier: usize, logging: Logger) -> (Self::Pusher, Self::Puller) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@
 #[macro_use]
 extern crate abomonation_derive;
 extern crate abomonation;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate timely_communication;
 extern crate timely_bytes;
 extern crate timely_logging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ pub mod logging;
 /// A composite trait for types usable as data in timely dataflow.
 ///
 /// The `Data` trait is necessary for all types that go along timely dataflow channels.
-pub trait Data: ::abomonation::Abomonation+Clone+'static { }
-impl<T: ::abomonation::Abomonation+Clone+'static> Data for T { }
+pub trait Data: Clone+'static { }
+impl<T: Clone+'static> Data for T { }
 
 /// A composite trait for types usable on exchange channels in timely dataflow.
 ///

--- a/src/progress/nested/product.rs
+++ b/src/progress/nested/product.rs
@@ -4,9 +4,6 @@ use std::fmt::{Formatter, Error, Debug};
 
 use ::order::{PartialOrder, TotalOrder};
 use progress::Timestamp;
-
-use abomonation::Abomonation;
-
 use progress::timestamp::Refines;
 
 impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
@@ -25,7 +22,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, T
 ///
 /// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrd`,
 /// because Rust just uses the lexicographic total order.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd)]
+#[derive(Abomonation, Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub struct Product<TOuter, TInner> {
     /// Outer timestamp.
     pub outer: TOuter,
@@ -78,19 +75,6 @@ impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<Product<TOuter, TInner>> 
                 self.inner.followed_by(&other.inner)
                     .map(|inner| Product::new(outer, inner))
             )
-    }
-}
-
-impl<TOuter: Abomonation, TInner: Abomonation> Abomonation for Product<TOuter, TInner> {
-    unsafe fn entomb<W: ::std::io::Write>(&self, write: &mut W) -> ::std::io::Result<()> {
-        self.outer.entomb(write)?;
-        self.inner.entomb(write)?;
-        Ok(())
-    }
-    unsafe fn exhume<'a,'b>(&'a mut self, mut bytes: &'b mut [u8]) -> Option<&'b mut [u8]> {
-        let tmp = bytes; bytes = if let Some(bytes) = self.outer.exhume(tmp) { bytes } else { return None };
-        let tmp = bytes; bytes = if let Some(bytes) = self.inner.exhume(tmp) { bytes } else { return None };
-        Some(bytes)
     }
 }
 

--- a/src/progress/nested/product.rs
+++ b/src/progress/nested/product.rs
@@ -22,7 +22,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, T
 ///
 /// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrd`,
 /// because Rust just uses the lexicographic total order.
-#[derive(Abomonation, Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd)]
+#[derive(Abomonation, Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Product<TOuter, TInner> {
     /// Outer timestamp.
     pub outer: TOuter,

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -5,12 +5,11 @@ use std::any::Any;
 use std::default::Default;
 use std::hash::Hash;
 
-use abomonation::Abomonation;
-
+use communication::Data;
 use order::PartialOrder;
 
 /// A composite trait for types that serve as timestamps in timely dataflow.
-pub trait Timestamp: Clone+Eq+PartialOrder+Default+Debug+Send+Any+Abomonation+Hash+Ord {
+pub trait Timestamp: Clone+Eq+PartialOrder+Default+Debug+Send+Any+Data+Hash+Ord {
     /// A type summarizing action on a timestamp along a dataflow path.
     type Summary : PathSummary<Self> + 'static;
 }


### PR DESCRIPTION
This light re-organization removes the requirement that timely dataflow `Data` implement `Abomonation`. Instead, this requirement creeps in when you want to use exchange channels, where we invoke the communication crate's requirements. These could plausibly be reduced (or redefined, with flags) to serde or bincode traits. It isn't clear if they support sizing, but presumably at great cost and with much copying they can be made to work.