### PR TITLE
Generalize feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 - The communication crate now has a `bincode` feature flag which should swing serialization over to use serde's `Serialize` trait. While it seems to work the ergonomics are likely in flux, as the choice is crate-wide and doesn't allow you to pick and choose a la carte.
 
+- The `loop_variable` operator now takes a timestamp summary for the timestamp of its scope, not just the timestamp extending its parent scope. The old behavior can be recovered with `Product::new(Default::default(), summary)`, but the change allows cycles in more general scopes and seemed worth it. The operator also no longer takes a `limit`, and if you need to impose a limit other than the summary returning `None` you should use the `branch_when()` operator.
+
 
 ## 0.7.0
 

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -1,6 +1,5 @@
 extern crate timely;
 
-use timely::progress::nested::product::Product;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{LoopVariable, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
@@ -11,17 +10,17 @@ fn main() {
 
     timely::execute_from_args(std::env::args().skip(2), move |worker| {
 
-        worker.dataflow(move |scope| {
-            let (handle, stream) = scope.loop_variable::<u64>(iterations, 1);
+        worker.dataflow::<usize,_,_>(move |scope| {
+            let (handle, stream) = scope.loop_variable::<usize>(iterations, 1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",
-                vec![Product::new((), 0)],
+                vec![0],
                 move |_, _, notificator| {
                     while let Some((cap, _count)) = notificator.next() {
                         let mut time = cap.time().clone();
-                        time.inner += 1;
-                        if time.inner < iterations {
+                        time += 1;
+                        if time < iterations {
                             notificator.notify_at(cap.delayed(&time));
                         }
                     }

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -1,7 +1,7 @@
 extern crate timely;
 
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::{LoopVariable, ConnectLoop};
+use timely::dataflow::operators::{Feedback, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
 
 fn main() {
@@ -11,7 +11,7 @@ fn main() {
     timely::execute_from_args(std::env::args().skip(2), move |worker| {
 
         worker.dataflow(move |scope| {
-            let (handle, stream) = scope.loop_variable::<usize>(1);
+            let (handle, stream) = scope.feedback::<usize>(1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -10,16 +10,15 @@ fn main() {
 
     timely::execute_from_args(std::env::args().skip(2), move |worker| {
 
-        worker.dataflow::<usize,_,_>(move |scope| {
-            let (handle, stream) = scope.loop_variable::<usize>(iterations, 1);
+        worker.dataflow(move |scope| {
+            let (handle, stream) = scope.loop_variable::<usize>(1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",
                 vec![0],
                 move |_, _, notificator| {
                     while let Some((cap, _count)) = notificator.next() {
-                        let mut time = cap.time().clone();
-                        time += 1;
+                        let time = *cap.time() + 1;
                         if time < iterations {
                             notificator.notify_at(cap.delayed(&time));
                         }

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -41,7 +41,7 @@ fn main() {
 
         let start = std::time::Instant::now();
 
-        worker.dataflow(move |scope| {
+        worker.dataflow::<usize,_,_>(move |scope| {
 
             // generate part of a random graph.
             let graph = (0..edges / peers)
@@ -49,7 +49,7 @@ fn main() {
                 .to_stream(scope);
 
             // define a loop variable, for the (node, worker) pairs.
-            let (handle, stream) = scope.loop_variable(usize::max_value(), 1);
+            let (handle, stream) = scope.loop_variable(1usize);
 
             // use the stream of edges
             graph.binary_notify(

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -8,7 +8,7 @@ use rand::{Rng, SeedableRng, StdRng};
 use timely_sort::{RadixSorter, RadixSorterBase};
 use timely_sort::LSBRadixSorter as Sorter;
 
-use timely::dataflow::operators::{ToStream, Concat, LoopVariable, ConnectLoop};
+use timely::dataflow::operators::{ToStream, Concat, Feedback, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
 use timely::dataflow::channels::pact::Exchange;
 
@@ -49,7 +49,7 @@ fn main() {
                 .to_stream(scope);
 
             // define a loop variable, for the (node, worker) pairs.
-            let (handle, stream) = scope.loop_variable(1usize);
+            let (handle, stream) = scope.feedback(1usize);
 
             // use the stream of edges
             graph.binary_notify(

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -79,7 +79,7 @@ fn main() {
                     notify.for_each(|time, _num, _notify| {
 
                         // maybe process the graph
-                        if time.inner == 0 {
+                        if *time == 0 {
 
                             // print some diagnostic timing information
                             if index == 0 { println!("{:?}:\tsorting", start.elapsed()); }

--- a/examples/loopdemo.rs
+++ b/examples/loopdemo.rs
@@ -1,7 +1,7 @@
 extern crate timely;
 
-use timely::dataflow::{Scope, InputHandle, ProbeHandle};
-use timely::dataflow::operators::{Input, LoopVariable, Enter, Concat, Map, Filter, ConnectLoop, Leave, Probe};
+use timely::dataflow::{InputHandle, ProbeHandle};
+use timely::dataflow::operators::{Input, LoopVariable, Concat, Map, Filter, ConnectLoop, Probe};
 
 fn main() {
 
@@ -25,7 +25,7 @@ fn main() {
 
             let stream = scope.input_from(&mut input);
 
-            let (loop_handle, loop_stream) = scope.loop_variable(u64::max_value(), 1);
+            let (loop_handle, loop_stream) = scope.loop_variable(1);
 
             let step =
             stream

--- a/examples/loopdemo.rs
+++ b/examples/loopdemo.rs
@@ -25,22 +25,16 @@ fn main() {
 
             let stream = scope.input_from(&mut input);
 
-            scope
-                .iterative(|child| {
+            let (loop_handle, loop_stream) = scope.loop_variable(u64::max_value(), 1);
 
-                    let (loop_handle, loop_stream) = child.loop_variable(usize::max_value(), 1);
+            let step =
+            stream
+                .concat(&loop_stream)
+                .map(|x| if x % 2 == 0 { x / 2 } else { 3 * x + 1 })
+                .filter(|x| x > &1);
 
-                    let step =
-                    stream
-                        .enter(child)
-                        .concat(&loop_stream)
-                        .map(|x| if x % 2 == 0 { x / 2 } else { 3 * x + 1 })
-                        .filter(|x| x > &1);
-
-                    step.connect_loop(loop_handle);
-                    step.leave()
-                })
-                .probe_with(&mut probe);
+            step.connect_loop(loop_handle);
+            step.probe_with(&mut probe);
         });
 
         let ns_per_request = 1_000_000_000 / rate;

--- a/examples/loopdemo.rs
+++ b/examples/loopdemo.rs
@@ -1,7 +1,7 @@
 extern crate timely;
 
 use timely::dataflow::{InputHandle, ProbeHandle};
-use timely::dataflow::operators::{Input, LoopVariable, Concat, Map, Filter, ConnectLoop, Probe};
+use timely::dataflow::operators::{Input, Feedback, Concat, Map, Filter, ConnectLoop, Probe};
 
 fn main() {
 
@@ -25,7 +25,7 @@ fn main() {
 
             let stream = scope.input_from(&mut input);
 
-            let (loop_handle, loop_stream) = scope.loop_variable(1);
+            let (loop_handle, loop_stream) = scope.feedback(1);
 
             let step =
             stream

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -16,13 +16,13 @@ fn main() {
         let mut input = InputHandle::new();
         let mut probe = ProbeHandle::new();
 
-        worker.dataflow(|scope| {
+        worker.dataflow::<usize,_,_>(|scope| {
 
             // create a new input, into which we can push edge changes.
             let edge_stream = input.to_stream(scope);
 
             // create a new feedback stream, which will be changes to ranks.
-            let (handle, rank_stream) = scope.loop_variable(usize::max_value(), 1);
+            let (handle, rank_stream) = scope.loop_variable(1);
 
             // bring edges and ranks together!
             let changes = edge_stream.binary_frontier(

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::{InputHandle, ProbeHandle};
-use timely::dataflow::operators::{LoopVariable, ConnectLoop, Probe};
+use timely::dataflow::operators::{Feedback, ConnectLoop, Probe};
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::channels::pact::Exchange;
 
@@ -22,7 +22,7 @@ fn main() {
             let edge_stream = input.to_stream(scope);
 
             // create a new feedback stream, which will be changes to ranks.
-            let (handle, rank_stream) = scope.loop_variable(1);
+            let (handle, rank_stream) = scope.feedback(1);
 
             // bring edges and ranks together!
             let changes = edge_stream.binary_frontier(

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -4,7 +4,6 @@ extern crate timely;
 use std::collections::HashMap;
 use rand::{Rng, SeedableRng, StdRng};
 
-use timely::progress::nested::product::Product;
 use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{LoopVariable, ConnectLoop, Probe};
 use timely::dataflow::operators::generic::Operator;
@@ -170,7 +169,7 @@ fn main() {
             input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
         }
 
-        input.advance_to(Product::new((), 1));
+        input.advance_to(1);
 
         while probe.less_than(input.time()) {
             worker.step();
@@ -179,7 +178,7 @@ fn main() {
         for i in 1 .. 1000 {
             input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
             input.send(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)), -1));
-            input.advance_to(Product::new((), 1 + i));
+            input.advance_to(i + 1);
             while probe.less_than(input.time()) {
                 worker.step();
             }

--- a/examples/pingpong.rs
+++ b/examples/pingpong.rs
@@ -12,7 +12,7 @@ fn main() {
         let index = worker.index();
         let peers = worker.peers();
         worker.dataflow::<u64,_,_>(move |scope| {
-            let (helper, cycle) = scope.loop_variable(1);
+            let (helper, cycle) = scope.feedback(1);
             (0 .. elements)
                   .filter(move |&x| (x as usize) % peers == index)
                   .to_stream(scope)

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -29,14 +29,12 @@ pub trait LoopVariable<G: Scope> {
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
     ///
     /// timely::example(|scope| {
-    ///     scope.scoped("Loop", |scope| {
-    ///         // circulate 0..10 for 100 iterations.
-    ///         let (handle, cycle) = scope.loop_variable(100, 1);
-    ///         (0..10).to_stream(scope)
-    ///                .concat(&cycle)
-    ///                .inspect(|x| println!("seen: {:?}", x))
-    ///                .connect_loop(handle);
-    ///     });
+    ///     // circulate 0..10 for 100 iterations.
+    ///     let (handle, cycle) = scope.loop_variable(100, 1);
+    ///     (0..10).to_stream(scope)
+    ///            .concat(&cycle)
+    ///            .inspect(|x| println!("seen: {:?}", x))
+    ///            .connect_loop(handle);
     /// });
     /// ```
     fn loop_variable<D: Data>(&mut self, limit: G::Timestamp, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G::Timestamp, D>, Stream<G, D>);
@@ -106,14 +104,12 @@ pub trait ConnectLoop<G: Scope, D: Data> {
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
     ///
     /// timely::example(|scope| {
-    ///     scope.scoped("Loop", |scope| {
-    ///         // circulate 0..10 for 100 iterations.
-    ///         let (handle, cycle) = scope.loop_variable(100, 1);
-    ///         (0..10).to_stream(scope)
-    ///                .concat(&cycle)
-    ///                .inspect(|x| println!("seen: {:?}", x))
-    ///                .connect_loop(handle);
-    ///     });
+    ///     // circulate 0..10 for 100 iterations.
+    ///     let (handle, cycle) = scope.loop_variable(100, 1);
+    ///     (0..10).to_stream(scope)
+    ///            .concat(&cycle)
+    ///            .inspect(|x| println!("seen: {:?}", x))
+    ///            .connect_loop(handle);
     /// });
     /// ```
     fn connect_loop(&self, Handle<G::Timestamp, D>);

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -11,18 +11,12 @@ use progress::frontier::Antichain;
 use progress::nested::{Source, Target};
 use progress::ChangeBatch;
 
-use progress::nested::product::Product;
-// use progress::nested::Summary::Local;
-
 use dataflow::channels::Bundle;
 use dataflow::channels::pushers::{Counter, Tee};
-use worker::AsWorker;
-
-use dataflow::{Stream, Scope, ScopeParent};
-use dataflow::scopes::child::Iterative;
+use dataflow::{Stream, Scope};
 
 /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
-pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
+pub trait LoopVariable<G: Scope> {
     /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
     ///
     /// The resulting `Stream` will have its data defined by a future call to `connect_loop` with
@@ -45,26 +39,26 @@ pub trait LoopVariable<'a, G: ScopeParent, T: Timestamp> {
     ///     });
     /// });
     /// ```
-    fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Iterative<'a, G, T>, D>);
+    fn loop_variable<D: Data>(&mut self, limit: G::Timestamp, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G::Timestamp, D>, Stream<G, D>);
 }
 
-impl<'a, G: ScopeParent, T: Timestamp> LoopVariable<'a, G, T> for Iterative<'a, G, T> {
-    fn loop_variable<D: Data>(&mut self, limit: T, summary: T::Summary) -> (Handle<G::Timestamp, T, D>, Stream<Iterative<'a, G, T>, D>) {
+impl<G: Scope> LoopVariable<G> for G {
+    fn loop_variable<D: Data>(&mut self, limit: G::Timestamp, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G::Timestamp, D>, Stream<G, D>) {
 
-        let (targets, registrar) = Tee::<Product<G::Timestamp, T>, D>::new();
+        let (targets, registrar) = Tee::<G::Timestamp, D>::new();
 
         let feedback_output = Counter::new(targets);
-        let produced = feedback_output.produced().clone();
+        let produced_messages = feedback_output.produced().clone();
 
         let feedback_input =  Counter::new(Observer {
             limit, summary: summary.clone(), targets: feedback_output
         });
-        let consumed = feedback_input.produced().clone();
+        let consumed_messages = feedback_input.produced().clone();
 
         let index = self.add_operator(Box::new(Operator {
-            consumed_messages:  consumed,
-            produced_messages:  produced,
-            summary:            Product::new(Default::default(), summary),
+            consumed_messages,
+            produced_messages,
+            summary,
         }));
 
         let helper = Handle {
@@ -77,20 +71,20 @@ impl<'a, G: ScopeParent, T: Timestamp> LoopVariable<'a, G, T> for Iterative<'a, 
 }
 
 // implementation of the feedback vertex, essentially, as an observer
-struct Observer<TOuter: Timestamp, TInner: Timestamp, D:Data> {
-    limit:      TInner,
-    summary:    TInner::Summary,
-    targets:    Counter<Product<TOuter, TInner>, D, Tee<Product<TOuter, TInner>, D>>,
+struct Observer<T: Timestamp, D:Data> {
+    limit:      T,
+    summary:    T::Summary,
+    targets:    Counter<T, D, Tee<T, D>>,
 }
 
-impl<TOuter: Timestamp, TInner: Timestamp, D: Data> Push<Bundle<Product<TOuter, TInner>, D>> for Observer<TOuter, TInner, D> {
+impl<T: Timestamp, D: Data> Push<Bundle<T, D>> for Observer<T, D> {
     #[inline]
-    fn push(&mut self, message: &mut Option<Bundle<Product<TOuter, TInner>, D>>) {
+    fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         let active = if let Some(message) = message {
             let message = message.as_mut();
-            if let Some(new_time) = self.summary.results_in(&message.time.inner) {
-                message.time.inner = new_time;
-                message.time.inner.less_equal(&self.limit)
+            if let Some(new_time) = self.summary.results_in(&message.time) {
+                message.time = new_time;
+                message.time.less_equal(&self.limit)
             }
             else {
                 false
@@ -103,7 +97,7 @@ impl<TOuter: Timestamp, TInner: Timestamp, D: Data> Push<Bundle<Product<TOuter, 
 }
 
 /// Connect a `Stream` to the input of a loop variable.
-pub trait ConnectLoop<G: ScopeParent, T: Timestamp, D: Data> {
+pub trait ConnectLoop<G: Scope, D: Data> {
     /// Connect a `Stream` to be the input of a loop variable.
     ///
     /// # Examples
@@ -122,20 +116,20 @@ pub trait ConnectLoop<G: ScopeParent, T: Timestamp, D: Data> {
     ///     });
     /// });
     /// ```
-    fn connect_loop(&self, Handle<G::Timestamp, T, D>);
+    fn connect_loop(&self, Handle<G::Timestamp, D>);
 }
 
-impl<'a, G: ScopeParent, T: Timestamp, D: Data> ConnectLoop<G, T, D> for Stream<Iterative<'a, G, T>, D> {
-    fn connect_loop(&self, helper: Handle<G::Timestamp, T, D>) {
+impl<G: Scope, D: Data> ConnectLoop<G, D> for Stream<G, D> {
+    fn connect_loop(&self, helper: Handle<G::Timestamp, D>) {
         let channel_id = self.scope().new_identifier();
         self.connect_to(Target { index: helper.index, port: 0 }, helper.target, channel_id);
     }
 }
 
 /// A handle used to bind the source of a loop variable.
-pub struct Handle<TOuter: Timestamp, TInner: Timestamp, D: Data> {
+pub struct Handle<T: Timestamp, D: Data> {
     index:  usize,
-    target: Counter<Product<TOuter, TInner>, D, Observer<TOuter, TInner, D>>
+    target: Counter<T, D, Observer<T, D>>
 }
 
 // the scope that the progress tracker interacts with

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -12,7 +12,7 @@ pub use self::enterleave::{Enter, EnterAt, Leave};
 // pub use self::queue::*;
 pub use self::input::Input;
 pub use self::unordered_input::UnorderedInput;
-pub use self::feedback::{LoopVariable, ConnectLoop};
+pub use self::feedback::{Feedback, LoopVariable, ConnectLoop};
 pub use self::concat::{Concat, Concatenate};
 pub use self::partition::Partition;
 pub use self::map::Map;

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -1,8 +1,8 @@
 extern crate timely;
-extern crate timely_communication;
+// extern crate timely_communication;
 
 use timely::Configuration;
-use timely::progress::nested::product::Product;
+// use timely::progress::nested::product::Product;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{LoopVariable, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
@@ -12,21 +12,21 @@ use timely::dataflow::operators::generic::operator::Operator;
 #[test] fn barrier_sync_3w() { barrier_sync_helper(Configuration::Process(3)); }
 
 // This method asserts that each round of execution is notified of at most one time.
-fn barrier_sync_helper(config: ::timely_communication::Configuration) {
+fn barrier_sync_helper(config: ::timely::Configuration) {
     timely::execute(config, move |worker| {
         worker.dataflow(move |scope| {
             let (handle, stream) = scope.loop_variable::<u64>(100, 1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",
-                vec![Product::new((), 0), Product::new((), 1)],
+                vec![0, 1],
                 move |_, _, notificator| {
                     let mut count = 0;
                     while let Some((cap, _count)) = notificator.next() {
                         count += 1;
                         let mut time = cap.time().clone();
-                        time.inner += 1;
-                        if time.inner < 100 {
+                        time += 1;
+                        if time < 100 {
                             notificator.notify_at(cap.delayed(&time));
                         }
                     }

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -1,8 +1,6 @@
 extern crate timely;
-// extern crate timely_communication;
 
 use timely::Configuration;
-// use timely::progress::nested::product::Product;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{LoopVariable, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
@@ -15,7 +13,7 @@ use timely::dataflow::operators::generic::operator::Operator;
 fn barrier_sync_helper(config: ::timely::Configuration) {
     timely::execute(config, move |worker| {
         worker.dataflow(move |scope| {
-            let (handle, stream) = scope.loop_variable::<u64>(100, 1);
+            let (handle, stream) = scope.loop_variable::<u64>(1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",
@@ -24,8 +22,7 @@ fn barrier_sync_helper(config: ::timely::Configuration) {
                     let mut count = 0;
                     while let Some((cap, _count)) = notificator.next() {
                         count += 1;
-                        let mut time = cap.time().clone();
-                        time += 1;
+                        let time = *cap.time() + 1;
                         if time < 100 {
                             notificator.notify_at(cap.delayed(&time));
                         }

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -2,7 +2,7 @@ extern crate timely;
 
 use timely::Configuration;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::{LoopVariable, ConnectLoop};
+use timely::dataflow::operators::{Feedback, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
 
 #[test] fn barrier_sync_1w() { barrier_sync_helper(Configuration::Thread); }
@@ -13,7 +13,7 @@ use timely::dataflow::operators::generic::operator::Operator;
 fn barrier_sync_helper(config: ::timely::Configuration) {
     timely::execute(config, move |worker| {
         worker.dataflow(move |scope| {
-            let (handle, stream) = scope.loop_variable::<u64>(1);
+            let (handle, stream) = scope.feedback::<u64>(1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",


### PR DESCRIPTION
This PR changes the interface to `loop_variable` so that the limit and the summary are with respect to the ambient timestamp, not only the one coordinate added by a product combinator. This allows feedback in a greater variety of settings, but adds the complication that one must determine a limit and summary for a more complex type.

The summary should be as simple as `Product::new(Default::default(), summary)`, which isn't especially simple but is at least tractable (and we could simplify it with helper methods).

The limit is harder, because timestamps do not expose a "maximum" method. We would want the limit to be `Product::new(Parent::maximum(), limit)`, but .. right now this is up for debate.

Another option would be to accept a closure determining the limit, which results in a great many `impl Fn(&T)->bool` types in structs (the loop handles), and I don't know the extent to which this is supported yet. Another option is to delete the limit functionality, and ask users to filter their own data if they want to terminate loops early (e.g. with the `branch` method).