### PR TITLE
race in dataflow construction

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timely_communication"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Communication layer for timely dataflow"
 

--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -152,7 +152,6 @@ impl<A: Allocate> Allocate for TcpAllocator<A> {
             }
         }
 
-
         let channel =
         self.to_local
             .entry(identifier)

--- a/communication/src/allocator/zero_copy/allocator_process.rs
+++ b/communication/src/allocator/zero_copy/allocator_process.rs
@@ -133,9 +133,13 @@ impl Allocate for ProcessAllocator {
             pushes.push(Box::new(Pusher::new(header, self.sends[target_index].clone())));
         }
 
-        self.to_local.insert(identifier, Rc::new(RefCell::new(VecDeque::new())));
+        let channel =
+        self.to_local
+            .entry(identifier)
+            .or_insert_with(|| Rc::new(RefCell::new(VecDeque::new())))
+            .clone();
 
-        let puller = Box::new(Puller::new(self.to_local[&identifier].clone()));
+        let puller = Box::new(Puller::new(channel));
 
         (pushes, puller)
     }
@@ -184,8 +188,8 @@ impl Allocate for ProcessAllocator {
 
         // OPTIONAL: Tattle on channels sitting on borrowed data.
         // OPTIONAL: Perhaps copy borrowed data into owned allocation.
-        // for index in 0 .. self.to_local.len() {
-        //     let len = self.to_local[index].borrow_mut().len();
+        // for (index, list) in self.to_local.iter() {
+        //     let len = list.borrow_mut().len();
         //     if len > 0 {
         //         eprintln!("Warning: worker {}, undrained channel[{}].len() = {}", self.index, index, len);
         //     }


### PR DESCRIPTION
This PR fixes a race in dataflow construction, in which a message received before the corresponding dataflow graph was constructed would be dropped. The message was actually being kept, in a queue associated with the intended channel, but when the dataflow graph was build it overwrote that queue, dropping the message. This fixes that.