### PR TITLE
hang less often

### DIFF
--- a/communication/src/allocator/zero_copy/bytes_exchange.rs
+++ b/communication/src/allocator/zero_copy/bytes_exchange.rs
@@ -78,7 +78,7 @@ impl MergeQueue {
     /// Indicates that all input handles to the queue have dropped.
     pub fn is_complete(&self) -> bool {
         if self.panic.load(Ordering::SeqCst) { panic!("MergeQueue poisoned."); }
-        Arc::strong_count(&self.queue) == 1
+        Arc::strong_count(&self.queue) == 1 && self.queue.lock().expect("Failed to acquire lock").is_empty()
     }
 }
 

--- a/communication/src/allocator/zero_copy/tcp.rs
+++ b/communication/src/allocator/zero_copy/tcp.rs
@@ -135,11 +135,16 @@ pub fn send_loop(
 
         if stash.is_empty() {
             // No evidence of records to read, but sources not yet empty (at start of loop).
-            // We are going to flush our writer (to move buffered data) and wait on a signal.
+            // We are going to flush our writer (to move buffered data), double check on the
+            // sources for emptiness and wait on a signal only if we are sure that there will
+            // still be a signal incoming.
+            //
             // We could get awoken by more data, a channel closing, or spuriously perhaps.
             writer.flush().expect("Failed to flush writer.");
-            signal.wait();
             sources.retain(|source| !source.is_complete());
+            if !sources.is_empty() {
+                signal.wait();
+            }
         }
         else {
             // TODO: Could do scatter/gather write here.


### PR DESCRIPTION
A thorough investigation by a crack team of scientists has concluded that this PR most likely fixes #198. The problem there was a non-deterministic hang on shutdown.

Roughly what was happening is that each send thread has a queue coming from each worker, and when this queue becomes "complete" it is dropped, and once all queues are complete the thread can exit. What constitutes "complete"? We had been using the rule that "if the worker has dropped the send handle", which prevents further sends!

That is pretty smart, but there is something else to check too! See if you can spot it in the diff. 