### PR TITLE
Reachability

### DIFF
--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -4,8 +4,11 @@ fn main() {
     let nodes: usize = std::env::args().nth(1).unwrap().parse().unwrap();
     let rounds: usize = std::env::args().nth(2).unwrap().parse().unwrap();
 
-    test_alt(nodes, rounds);
-    test_neu(nodes, rounds);
+    let alt = std::env::args().any(|x| x == "alt");
+    let neu = std::env::args().any(|x| x == "neu");
+
+    if alt { test_alt(nodes, rounds); }
+    if neu { test_neu(nodes, rounds); }
 }
 
 

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -12,7 +12,7 @@ fn main() {
 fn test_alt(nodes: usize, rounds: usize) {
 
     use timely::progress::frontier::Antichain;
-    use timely::progress::nested::subgraph::{Source, Target};
+    use timely::progress::{Source, Target};
     use timely::progress::nested::reachability::{Builder, Tracker};
 
     // This test means to exercise the efficiency of the tracker by performing local changes and expecting
@@ -76,7 +76,7 @@ fn test_alt(nodes: usize, rounds: usize) {
 fn test_neu(nodes: usize, rounds: usize) {
 
     use timely::progress::frontier::Antichain;
-    use timely::progress::nested::subgraph::{Source, Target};
+    use timely::progress::{Source, Target};
     use timely::progress::nested::reachability_neu::Builder;
 
     // This test means to exercise the efficiency of the tracker by performing local changes and expecting

--- a/src/dataflow/operators/broadcast.rs
+++ b/src/dataflow/operators/broadcast.rs
@@ -3,7 +3,7 @@
 use communication::Pull;
 
 use ::ExchangeData;
-use progress::nested::subgraph::{Source, Target};
+use progress::{Source, Target};
 use dataflow::{Stream, Scope};
 use progress::ChangeBatch;
 use progress::{Timestamp, Operate, Antichain};

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -25,7 +25,7 @@ use std::marker::PhantomData;
 
 use progress::Timestamp;
 use progress::timestamp::Refines;
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::nested::product::Product;
 use Data;
 use communication::Push;

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -26,7 +26,7 @@ use std::marker::PhantomData;
 use progress::Timestamp;
 use progress::timestamp::Refines;
 use progress::{Source, Target};
-use progress::nested::product::Product;
+use order::Product;
 use Data;
 use communication::Push;
 use dataflow::channels::pushers::{Counter, Tee};

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -8,7 +8,7 @@ use communication::Push;
 
 use progress::{Timestamp, Operate, PathSummary};
 use progress::frontier::Antichain;
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::nested::product::Product;
 use progress::ChangeBatch;
 

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -9,7 +9,7 @@ use communication::Push;
 use progress::{Timestamp, Operate, PathSummary};
 use progress::frontier::Antichain;
 use progress::{Source, Target};
-use progress::nested::product::Product;
+use order::Product;
 use progress::ChangeBatch;
 
 use dataflow::channels::Bundle;

--- a/src/dataflow/operators/generic/builder_raw.rs
+++ b/src/dataflow/operators/generic/builder_raw.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 
 use ::Data;
 
-use progress::nested::subgraph::{Source, Target};
+use progress::{Source, Target};
 use progress::ChangeBatch;
 use progress::{Timestamp, Operate, Antichain};
 

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -108,7 +108,7 @@ fn notificator_delivers_notifications_in_topo_order() {
     use std::cell::RefCell;
     use progress::ChangeBatch;
     use progress::frontier::MutableAntichain;
-    use progress::nested::product::Product;
+    use order::Product;
     use dataflow::operators::capability::mint as mint_capability;
 
     let mut frontier = MutableAntichain::new_bottom(Product::new(0, 0));

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -6,7 +6,7 @@ use std::default::Default;
 
 use progress::frontier::Antichain;
 use progress::{Operate, Timestamp, ChangeBatch};
-use progress::nested::Source;
+use progress::Source;
 
 use Data;
 use communication::Push;

--- a/src/dataflow/operators/partition.rs
+++ b/src/dataflow/operators/partition.rs
@@ -1,7 +1,7 @@
 //! Partition a stream of records into multiple streams.
 
 use progress::{Timestamp, Operate};
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::ChangeBatch;
 
 use Data;

--- a/src/dataflow/operators/unordered_input.rs
+++ b/src/dataflow/operators/unordered_input.rs
@@ -6,7 +6,7 @@ use std::default::Default;
 
 use progress::frontier::Antichain;
 use progress::{Operate, Timestamp};
-use progress::nested::subgraph::Source;
+use progress::Source;
 use progress::ChangeBatch;
 
 use Data;

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 
 use progress::{Timestamp, Operate, SubgraphBuilder};
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::timestamp::Refines;
 use progress::nested::product::Product;
 use communication::{Allocate, Data, Push, Pull};

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use progress::{Timestamp, Operate, SubgraphBuilder};
 use progress::{Source, Target};
 use progress::timestamp::Refines;
-use progress::nested::product::Product;
+use order::Product;
 use communication::{Allocate, Data, Push, Pull};
 use logging::TimelyLogger as Logger;
 use worker::AsWorker;

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -1,7 +1,7 @@
 //! Hierarchical organization of timely dataflow graphs.
 
 use progress::{Timestamp, Operate, Source, Target};
-use progress::nested::product::Product;
+use order::Product;
 use progress::timestamp::Refines;
 use communication::Allocate;
 use worker::AsWorker;
@@ -78,7 +78,7 @@ pub trait Scope: ScopeParent {
     /// ```
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Input, Enter, Leave};
-    /// use timely::progress::nested::product::Product;
+    /// use timely::order::Product;
     ///
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -1,7 +1,7 @@
 //! Hierarchical organization of timely dataflow graphs.
 
-use progress::{Timestamp, Operate};
-use progress::nested::{Source, Target, product::Product};
+use progress::{Timestamp, Operate, Source, Target};
+use progress::nested::product::Product;
 use progress::timestamp::Refines;
 use communication::Allocate;
 use worker::AsWorker;

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -4,7 +4,7 @@
 //! operator output. Extension methods on the `Stream` type provide the appearance of higher-level
 //! declarative programming, while constructing a dataflow graph underneath.
 
-use progress::nested::subgraph::{Source, Target};
+use progress::{Source, Target};
 
 use communication::Push;
 use dataflow::Scope;

--- a/src/order.rs
+++ b/src/order.rs
@@ -46,3 +46,94 @@ macro_rules! implement_total {
 
 implement_partial!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, (), ::std::time::Duration,);
 implement_total!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, (), ::std::time::Duration,);
+
+
+use std::fmt::{Formatter, Error, Debug};
+
+use progress::Timestamp;
+use progress::timestamp::Refines;
+
+impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
+    fn to_inner(other: TOuter) -> Self {
+        Product::new(other, Default::default())
+    }
+    fn to_outer(self: Product<TOuter, TInner>) -> TOuter {
+        self.outer
+    }
+    fn summarize(path: <Self as Timestamp>::Summary) -> <TOuter as Timestamp>::Summary {
+        path.outer
+    }
+}
+
+/// A nested pair of timestamps, one outer and one inner.
+///
+/// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrd`,
+/// because Rust just uses the lexicographic total order.
+#[derive(Abomonation, Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct Product<TOuter, TInner> {
+    /// Outer timestamp.
+    pub outer: TOuter,
+    /// Inner timestamp.
+    pub inner: TInner,
+}
+
+impl<TOuter, TInner> Product<TOuter, TInner> {
+    /// Creates a new product from outer and inner coordinates.
+    pub fn new(outer: TOuter, inner: TInner) -> Product<TOuter, TInner> {
+        Product {
+            outer,
+            inner,
+        }
+    }
+}
+
+/// Debug implementation to avoid seeing fully qualified path names.
+impl<TOuter: Debug, TInner: Debug> Debug for Product<TOuter, TInner> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        f.write_str(&format!("({:?}, {:?})", self.outer, self.inner))
+    }
+}
+
+impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter, TInner> {
+    #[inline(always)]
+    fn less_equal(&self, other: &Self) -> bool {
+        self.outer.less_equal(&other.outer) && self.inner.less_equal(&other.inner)
+    }
+}
+
+impl<TOuter: Timestamp, TInner: Timestamp> Timestamp for Product<TOuter, TInner> {
+    type Summary = Product<TOuter::Summary, TInner::Summary>;
+}
+
+use progress::timestamp::PathSummary;
+impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<Product<TOuter, TInner>> for Product<TOuter::Summary, TInner::Summary> {
+    #[inline]
+    fn results_in(&self, product: &Product<TOuter, TInner>) -> Option<Product<TOuter, TInner>> {
+        self.outer.results_in(&product.outer)
+            .and_then(|outer|
+                self.inner.results_in(&product.inner)
+                    .map(|inner| Product::new(outer, inner))
+            )
+    }
+    #[inline]
+    fn followed_by(&self, other: &Product<TOuter::Summary, TInner::Summary>) -> Option<Product<TOuter::Summary, TInner::Summary>> {
+        self.outer.followed_by(&other.outer)
+            .and_then(|outer|
+                self.inner.followed_by(&other.inner)
+                    .map(|inner| Product::new(outer, inner))
+            )
+    }
+}
+
+/// A type that does not affect total orderedness.
+///
+/// This trait is not useful, but must be made public and documented or else Rust
+/// complains about its existence in the constraints on the implementation of
+/// public traits for public types.
+pub trait Empty : PartialOrder { }
+
+impl Empty for () { }
+impl<T1: Empty, T2: Empty> Empty for Product<T1, T2> { }
+
+impl<T1, T2> TotalOrder for Product<T1, T2> where T1: Empty, T2: TotalOrder { }
+

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -31,6 +31,10 @@ impl Location {
     pub fn new_source(node: usize, port: usize) -> Location {
         Location { node, port: Port::Source(port) }
     }
+    /// If the location is a target.
+    pub fn is_target(&self) -> bool { if let Port::Target(_) = self.port { true } else { false } }
+    /// If the location is a source.
+    pub fn is_source(&self) -> bool { if let Port::Source(_) = self.port { true } else { false } }
 }
 
 impl From<Target> for Location {

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -14,7 +14,7 @@ pub mod operate;
 pub mod broadcast;
 
 /// A timely dataflow location.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Abomonation, Serialize, Deserialize)]
 pub struct Location {
     /// A scope-local operator identifier.
     node: usize,
@@ -56,7 +56,7 @@ impl From<Source> for Location {
 }
 
 /// An operator port.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Abomonation, Serialize, Deserialize)]
 pub enum Port {
     /// An operator input.
     Target(usize),

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -1,7 +1,7 @@
 //! Progress tracking mechanisms to support notification in timely dataflow
 
 pub use self::operate::Operate;
-pub use self::nested::{Subgraph, SubgraphBuilder, Source, Target};
+pub use self::nested::{Subgraph, SubgraphBuilder};
 pub use self::timestamp::{Timestamp, PathSummary};
 pub use self::change_batch::ChangeBatch;
 pub use self::frontier::Antichain;
@@ -12,3 +12,74 @@ pub mod nested;
 pub mod timestamp;
 pub mod operate;
 pub mod broadcast;
+
+/// A timely dataflow location.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Location {
+    /// A scope-local operator identifier.
+    node: usize,
+    /// An operator port identifier.`
+    port: Port,
+}
+
+impl Location {
+    /// Creates a new target location (operator input or scope output).
+    pub fn new_target(node: usize, port: usize) -> Location {
+        Location { node, port: Port::Target(port) }
+    }
+    /// Creates a new source location (operator output or scope input).
+    pub fn new_source(node: usize, port: usize) -> Location {
+        Location { node, port: Port::Source(port) }
+    }
+}
+
+impl From<Target> for Location {
+    fn from(target: Target) -> Self {
+        Location {
+            node: target.index,
+            port: Port::Target(target.port),
+        }
+    }
+}
+
+impl From<Source> for Location {
+    fn from(source: Source) -> Self {
+        Location {
+            node: source.index,
+            port: Port::Source(source.port),
+        }
+    }
+}
+
+/// An operator port.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Port {
+    /// An operator input.
+    Target(usize),
+    /// An operator output.
+    Source(usize),
+}
+
+/// Names a source of a data stream.
+///
+/// A source of data is either a child output, or an input from a parent.
+/// Conventionally, `index` zero is used for parent input.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct Source {
+    /// Index of the source operator.
+    pub index: usize,
+    /// Number of the output port from the operator.
+    pub port: usize,
+}
+
+/// Names a target of a data stream.
+///
+/// A target of data is either a child input, or an output to a parent.
+/// Conventionally, `index` zero is used for parent output.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct Target {
+    /// Index of the target operator.
+    pub index: usize,
+    /// Number of the input port to the operator.
+    pub port: usize,
+}

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -3,7 +3,7 @@
 pub use self::subgraph::{Subgraph, SubgraphBuilder};
 
 pub mod pointstamp_counter;
-pub mod product;
+// pub mod product;
 pub mod subgraph;
 pub mod reachability;
 pub mod reachability_neu;

--- a/src/progress/nested/mod.rs
+++ b/src/progress/nested/mod.rs
@@ -1,7 +1,6 @@
 //! Coordination of progress information between a scope-as-operator and its children operators.
 
 pub use self::subgraph::{Subgraph, SubgraphBuilder};
-pub use self::subgraph::{Source, Target};
 
 pub mod pointstamp_counter;
 pub mod product;

--- a/src/progress/nested/pointstamp_counter.rs
+++ b/src/progress/nested/pointstamp_counter.rs
@@ -1,7 +1,7 @@
 //! Manages pointstamp counts (timestamp, location) within a sub operator.
 
 use progress::Timestamp;
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::ChangeBatch;
 
 /// Represents changes to pointstamps before and after transmission along a scope's topology.

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -41,7 +41,7 @@
 //! ```
 
 use progress::Timestamp;
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::ChangeBatch;
 
 use progress::frontier::{Antichain, MutableAntichain};

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -9,7 +9,7 @@
 //!
 //! ```rust
 //! use timely::progress::frontier::Antichain;
-//! use timely::progress::nested::subgraph::{Source, Target};
+//! use timely::progress::{Source, Target};
 //! use timely::progress::nested::reachability::{Builder, Tracker};
 //!
 //! // allocate a new empty topology builder.
@@ -71,7 +71,7 @@ use order::PartialOrder;
 ///
 /// ```rust
 /// use timely::progress::frontier::Antichain;
-/// use timely::progress::nested::subgraph::{Source, Target};
+/// use timely::progress::{Source, Target};
 /// use timely::progress::nested::reachability::Builder;
 ///
 /// // allocate a new empty topology builder.
@@ -298,7 +298,7 @@ pub struct Summary<T: Timestamp> {
 ///
 /// ```rust
 /// use timely::progress::frontier::Antichain;
-/// use timely::progress::nested::subgraph::{Source, Target};
+/// use timely::progress::{Source, Target};
 /// use timely::progress::nested::reachability::{Builder, Tracker};
 ///
 /// // allocate a new empty topology builder.

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -41,7 +41,7 @@
 //! ```
 
 use progress::Timestamp;
-use progress::{Source, Target};
+use progress::{Location, Port, Source, Target};
 use progress::ChangeBatch;
 
 use progress::frontier::{Antichain, MutableAntichain};
@@ -348,6 +348,15 @@ pub struct Tracker<T:Timestamp> {
 }
 
 impl<T:Timestamp> Tracker<T> {
+
+    /// Updates theh count for a time at a location.
+    #[inline]
+    pub fn update(&mut self, location: Location, time: T, value: i64) {
+        match location.port {
+            Port::Target(port) => self.update_target(Target { index: location.node, port }, time, value),
+            Port::Source(port) => self.update_source(Source { index: location.node, port }, time, value),
+        }
+    }
 
     /// Updates the count for a time at a target.
     #[inline]

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -8,9 +8,9 @@
 //! # Examples
 //!
 //! ```rust
-//! use timely::progress::Location;
+//! use timely::progress::{Location, Port};
 //! use timely::progress::frontier::Antichain;
-//! use timely::progress::nested::subgraph::{Source, Target};
+//! use timely::progress::{Source, Target};
 //! use timely::progress::nested::reachability_neu::{Builder, Tracker};
 //!
 //! // allocate a new empty topology builder.
@@ -35,8 +35,16 @@
 //! // Propagate changes; until this call updates are simply buffered.
 //! tracker.propagate_all();
 //!
-//! let mut results = tracker.pushed().drain().collect::<Vec<_>>();
+//! let mut results =
+//! tracker
+//!     .pushed()
+//!     .drain()
+//!     .filter(|((location, time), delta)| location.is_target())
+//!     .collect::<Vec<_>>();
+//!
 //! results.sort();
+//!
+//! println!("{:?}", results);
 //!
 //! assert_eq!(results.len(), 3);
 //! assert_eq!(results[0], ((Location::new_target(0, 0), 18), 1));
@@ -49,7 +57,13 @@
 //! // Propagate changes; until this call updates are simply buffered.
 //! tracker.propagate_all();
 //!
-//! let mut results = tracker.pushed().drain().collect::<Vec<_>>();
+//! let mut results =
+//! tracker
+//!     .pushed()
+//!     .drain()
+//!     .filter(|((location, time), delta)| location.is_target())
+//!     .collect::<Vec<_>>();
+//!
 //! results.sort();
 //!
 //! assert_eq!(results.len(), 3);
@@ -92,7 +106,7 @@ use progress::timestamp::PathSummary;
 ///
 /// ```rust
 /// use timely::progress::frontier::Antichain;
-/// use timely::progress::nested::subgraph::{Source, Target};
+/// use timely::progress::{Source, Target};
 /// use timely::progress::nested::reachability_neu::Builder;
 ///
 /// // allocate a new empty topology builder.

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -1,4 +1,4 @@
-//! Manages pointstamp reachability within a graph.
+//! Manages pointstamp reachability within a timely dataflow graph.
 //!
 //! Timely dataflow is concerned with understanding and communicating the potential
 //! for capabilities to reach nodes in a directed graph, by following paths through
@@ -8,6 +8,7 @@
 //! # Examples
 //!
 //! ```rust
+//! use timely::progress::Location;
 //! use timely::progress::frontier::Antichain;
 //! use timely::progress::nested::subgraph::{Source, Target};
 //! use timely::progress::nested::reachability_neu::{Builder, Tracker};
@@ -38,9 +39,9 @@
 //! results.sort();
 //!
 //! assert_eq!(results.len(), 3);
-//! assert_eq!(results[0], ((Target { index: 0, port: 0 }, 18), 1));
-//! assert_eq!(results[1], ((Target { index: 1, port: 0 }, 17), 1));
-//! assert_eq!(results[2], ((Target { index: 2, port: 0 }, 17), 1));
+//! assert_eq!(results[0], ((Location::new_target(0, 0), 18), 1));
+//! assert_eq!(results[1], ((Location::new_target(1, 0), 17), 1));
+//! assert_eq!(results[2], ((Location::new_target(2, 0), 17), 1));
 //!
 //! // Introduce a pointstamp at the output of the first node.
 //! tracker.update_source(Source { index: 0, port: 0}, 17, -1);
@@ -52,17 +53,18 @@
 //! results.sort();
 //!
 //! assert_eq!(results.len(), 3);
-//! assert_eq!(results[0], ((Target { index: 0, port: 0 }, 18), -1));
-//! assert_eq!(results[1], ((Target { index: 1, port: 0 }, 17), -1));
-//! assert_eq!(results[2], ((Target { index: 2, port: 0 }, 17), -1));
+//! assert_eq!(results[0], ((Location::new_target(0, 0), 18), -1));
+//! assert_eq!(results[1], ((Location::new_target(1, 0), 17), -1));
+//! assert_eq!(results[2], ((Location::new_target(2, 0), 17), -1));
 //! ```
 
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::cmp::Reverse;
 
 use progress::Timestamp;
-use progress::nested::{Source, Target};
+use progress::{Source, Target};
 use progress::ChangeBatch;
+use progress::{Location, Port};
 
 use progress::frontier::{Antichain, MutableAntichain};
 use progress::timestamp::PathSummary;
@@ -185,38 +187,12 @@ impl<T: Timestamp> Builder<T> {
 
 /// An interactive tracker of propagated reachability information.
 ///
-/// A `Tracker` tracks, for a fixed graph topology, the consequences of
+/// A `Tracker` tracks, for a fixed graph topology, the implications of
 /// pointstamp changes at various node input and output ports. These changes may
 /// alter the potential pointstamps that could arrive at downstream input ports.
 
 #[derive(Debug)]
 pub struct Tracker<T:Timestamp> {
-
-    // TODO: All of the sizes of these allocations are static (except internal to `ChangeBatch`).
-    //       It seems we should be able to flatten most of these so that there are a few allocations
-    //       independent of the numbers of nodes and ports and such.
-    //
-    // TODO: We could also change the internal representation to be a graph of targets, using usize
-    //       identifiers for each, so that internally we needn't use multiple levels of indirection.
-    //       This may make more sense once we commit to topologically ordering the targets.
-
-    /// Each source and target has a mutable antichain to ensure that we track their discrete frontiers,
-    /// rather than their multiplicities. We separately track the frontiers resulting from propagated
-    /// frontiers, to protect them from transient negativity in inbound target updates.
-    sources: Vec<Vec<MutableAntichain<T>>>,
-    targets: Vec<Vec<MutableAntichain<T>>>,
-    pusheds: Vec<Vec<MutableAntichain<T>>>,
-
-    /// Source and target changes are buffered, which allows us to delay processing until propagation,
-    /// and so consolidate updates, but to leap directly to those frontiers that may have changed.
-    source_changes: ChangeBatch<(Source, T)>,
-    target_changes: ChangeBatch<(Target, T)>,
-
-    /// Worklist of updates to perform, ordered by increasing timestamp and target.
-    target_worklist: BinaryHeap<Reverse<(T, Target, i64)>>,
-
-    /// Buffer of consequent changes.
-    pushed_changes: ChangeBatch<(Target, T)>,
 
     /// Internal connections within hosted operators.
     ///
@@ -230,95 +206,136 @@ pub struct Tracker<T:Timestamp> {
     /// Indexed by operator index then output port.
     edges: Vec<Vec<Vec<Target>>>,
 
-    /// Compiled reach from each target to targets one hop downstream.
-    compiled: Vec<Vec<Vec<(Target, T::Summary)>>>,
+    // TODO: All of the sizes of these allocations are static (except internal to `ChangeBatch`).
+    //       It seems we should be able to flatten most of these so that there are a few allocations
+    //       independent of the numbers of nodes and ports and such.
+    //
+    // TODO: We could also change the internal representation to be a graph of targets, using usize
+    //       identifiers for each, so that internally we needn't use multiple levels of indirection.
+    //       This may make more sense once we commit to topologically ordering the targets.
+
+    /// Each source and target has a mutable antichain to ensure that we track their discrete frontiers,
+    /// rather than their multiplicities. We separately track the frontiers resulting from propagated
+    /// frontiers, to protect them from transient negativity in inbound target updates.
+    pointstamps: HashMap<Location, MutableAntichain<T>>,
+    implications: HashMap<Location, MutableAntichain<T>>,
+
+    /// Source and target changes are buffered, which allows us to delay processing until propagation,
+    /// and so consolidate updates, but to leap directly to those frontiers that may have changed.
+    input_changes: ChangeBatch<(Location, T)>,
+
+    /// Worklist of updates to perform, ordered by increasing timestamp and target.
+    worklist: BinaryHeap<Reverse<(T, Location, i64)>>,
+
+    /// Buffer of consequent changes.
+    pushed_changes: ChangeBatch<(Location, T)>,
+
+    /// Compiled summaries from each internal location (not scope inputs) to each scope output.
+    output_summaries: HashMap<Location, Vec<Antichain<T::Summary>>>,
+    output_changes: Vec<ChangeBatch<T>>,
+
+    global_frontier: HashSet<(Location, T)>,
 }
 
 impl<T:Timestamp> Tracker<T> {
 
-    /// Updates the count for a time at a target.
+    /// Updates the count for a time at a target (operator input, scope output).
     #[inline]
     pub fn update_target(&mut self, target: Target, time: T, value: i64) {
-        self.target_changes.update((target, time), value);
+        self.input_changes.update((Location::from(target), time), value);
     }
-    /// Updates the count for a time at a source.
+    /// Updates the count for a time at a source (operator output, scope input).
     #[inline]
     pub fn update_source(&mut self, source: Source, time: T, value: i64) {
-        self.source_changes.update((source, time), value);
+        self.input_changes.update((Location::from(source), time), value);
     }
 
     /// Allocate a new `Tracker` using the shape from `summaries`.
     pub fn allocate_from(builder: &Builder<T>) -> Self {
 
-        let mut sources = Vec::with_capacity(builder.shape.len());
-        let mut targets = Vec::with_capacity(builder.shape.len());
-        let mut pusheds = Vec::with_capacity(builder.shape.len());
-
-        let mut compiled = Vec::with_capacity(builder.shape.len());
+        let mut pointstamps = HashMap::new();
+        let mut implications = HashMap::new();
 
         // Allocate buffer space for each input and input port.
         for (node, &(inputs, outputs)) in builder.shape.iter().enumerate() {
-            sources.push(vec![MutableAntichain::new(); outputs]);
-            targets.push(vec![MutableAntichain::new(); inputs]);
-            pusheds.push(vec![MutableAntichain::new(); inputs]);
-
-            let mut compiled_node = vec![Vec::new(); inputs];
             for input in 0 .. inputs {
-                for output in 0 .. outputs {
-                    for summary in builder.nodes[node][input][output].elements().iter() {
-                        for &target in builder.edges[node][output].iter() {
-                            compiled_node[input].push((target, summary.clone()));
-                        }
-                    }
-                }
+                pointstamps.insert(Location { node, port: Port::Target(input) }, MutableAntichain::new());
+                implications.insert(Location { node, port: Port::Target(input) }, MutableAntichain::new());
             }
-            compiled.push(compiled_node);
+            for input in 0 .. outputs {
+                pointstamps.insert(Location { node, port: Port::Source(input) }, MutableAntichain::new());
+                implications.insert(Location { node, port: Port::Source(input) }, MutableAntichain::new());
+            }
         }
 
+        // Compile summaries from each location to each scope output.
+        let output_summaries = summarize_outputs::<T>(&builder.nodes, &builder.edges);
+
         Tracker {
-            sources,
-            targets,
-            pusheds,
-            source_changes: ChangeBatch::new(),
-            target_changes: ChangeBatch::new(),
-            target_worklist: BinaryHeap::new(),
-            pushed_changes: ChangeBatch::new(),
             nodes: builder.nodes.clone(),
             edges: builder.edges.clone(),
-            compiled,
+            pointstamps,
+            implications,
+            input_changes: ChangeBatch::new(),
+            worklist: BinaryHeap::new(),
+            pushed_changes: ChangeBatch::new(),
+            output_summaries,
+            output_changes: Vec::new(),
+            global_frontier: HashSet::new(),
         }
     }
 
     /// Propagates all pending updates.
+    ///
+    /// The method drains `self.input_changes` and circulates their implications
+    /// until we cease deriving new implications.
     pub fn propagate_all(&mut self) {
 
-        // Filter each target change through `self.targets`.
-        for ((target, time), diff) in self.target_changes.drain() {
-            let target_worklist = &mut self.target_worklist;
-            self.targets[target.index][target.port].update_iter_and(Some((time, diff)), |time, diff| {
-                target_worklist.push(Reverse((time.clone(), target, diff)))
-            })
+        // Reduces the input changes to actual discrete changes to a frontier.
+        // TODO: Commit changes to the same `location` in one batch.
+        let output_changes = &mut self.output_changes;
+        let output_summaries = &self.output_summaries;
+
+        // Step 1: Drain `self.input_changes` and determine actual frontier changes.
+        //
+        // Not all changes in `self.input_changes` may alter the frontier at a location.
+        // By filtering the changes through `self.pointstamps` we react only to discrete
+        // changes in the frontier, rather than changes in the pointstamp counts that
+        // witness that frontier.
+        for ((location, time), diff) in self.input_changes.drain() {
+            let worklist = &mut self.worklist;
+            self.pointstamps
+                .entry(location)
+                .or_insert(MutableAntichain::new())
+                .update_iter_and(Some((time, diff)), |time, diff| {
+
+                    // Update our worklist.
+                    worklist.push(Reverse((time.clone(), location.clone(), diff)));
+
+                    // Also propagate changes to the scope outputs.
+                    if let Some(summaries) = output_summaries.get(&location) {
+                        for (output, summaries) in summaries.iter().enumerate() {
+                            for summary in summaries.elements().iter() {
+                                if let Some(timestamp) = summary.results_in(time) {
+                                    while output_changes.len() <= output {
+                                        output_changes.push(ChangeBatch::new());
+                                    }
+                                    output_changes[output].update(timestamp, diff);
+                                }
+                            }
+                        }
+                    }
+                });
         }
 
-        // Filter each source change through `self.sources` and then along edges.
-        for ((source, time), diff) in self.source_changes.drain() {
-            let target_worklist = &mut self.target_worklist;
-            let edges = &self.edges[source.index][source.port];
-            self.sources[source.index][source.port].update_iter_and(Some((time, diff)), |time, diff| {
-                for &target in edges.iter() {
-                    target_worklist.push(Reverse((time.clone(), target, diff)))
-                }
-            })
-        }
+        // Step 2: Circulate implications of changes to `self.pointstamps`.
+        //
+        // TODO: The argument that this always terminates is subtle, and should be made.
+        while let Some(Reverse((time, location, mut diff))) = self.worklist.pop() {
 
-        while !self.target_worklist.is_empty() {
-
-            // This iteration we will drain all (target, time) work items.
-            let (time, target, mut diff) = self.target_worklist.pop().unwrap().0;
-
-            // Drain any other updates that might have the same time; accumulate difference.
-            while self.target_worklist.peek().map(|x| ((x.0).0 == time) && ((x.0).1 == target)).unwrap_or(false) {
-                diff += (self.target_worklist.pop().unwrap().0).2;
+            // Drain and accumulate all updates that have the same time and location.
+            while self.worklist.peek().map(|x| ((x.0).0 == time) && ((x.0).1 == location)).unwrap_or(false) {
+                diff += (self.worklist.pop().unwrap().0).2;
             }
 
             // Only act if there is a net change, positive or negative.
@@ -326,50 +343,199 @@ impl<T:Timestamp> Tracker<T> {
 
                 // Borrow various self fields to appease Rust.
                 let pushed_changes = &mut self.pushed_changes;
-                let target_worklist = &mut self.target_worklist;
-                let _edges = &self.edges[target.index];
-                let _nodes = &self.nodes[target.index][target.port];
-                let _compiled = &self.compiled[target.index][target.port];
+                let worklist = &mut self.worklist;
 
-                // Although single-element updates may seem wasteful, they are important for termination.
-                self.pusheds[target.index][target.port].update_iter_and(Some((time, diff)), |time, diff| {
-
-                    // Identify the change in the out change list.
-                    pushed_changes.update((target, time.clone()), diff);
-
-                    // When a target has its frontier change we should communicate the change to downstream
-                    // targets as well. This means traversing the operator to its outputs.
-                    //
-                    // We have two implementations, first traversing `nodes` and `edges`, and second using
-                    // a compiled representation that flattens all these lists (but has redundant calls to
-                    // `results_in`).
-
-                    // // Version 1.
-                    // for (output, summaries) in _nodes.iter().enumerate() {
-                    //     for summary in summaries.elements().iter() {
-                    //         if let Some(new_time) = summary.results_in(time) {
-                    //             for &new_target in _edges[output].iter() {
-                    //                 target_worklist.push(Reverse((new_time.clone(), new_target, diff)));
-                    //             }
-                    //         }
-                    //     }
-                    // }
-
-                    // Version 2.
-                    for &(new_target, ref summary) in _compiled.iter() {
-                        if let Some(new_time) = summary.results_in(time) {
-                            target_worklist.push(Reverse((new_time, new_target, diff)));
-                        }
+                match location.port {
+                    // Update to an operator input.
+                    // Propagate any changes forward across the operator.
+                    Port::Target(port_index) => {
+                        let nodes = &self.nodes[location.node][port_index];
+                        self.implications
+                            .entry(location)
+                            .or_insert(MutableAntichain::new())
+                            .update_iter_and(Some((time, diff)), |time, diff| {
+                                pushed_changes.update((location, time.clone()), diff);
+                                for (output_port, summaries) in nodes.iter().enumerate() {
+                                    for summary in summaries.elements().iter() {
+                                        if let Some(new_time) = summary.results_in(time) {
+                                            worklist.push(Reverse((
+                                                new_time,
+                                                Location {
+                                                    node: location.node,
+                                                    port: Port::Source(output_port)
+                                                },
+                                                diff
+                                            )));
+                                        }
+                                    }
+                                }
+                            });
                     }
-
-                })
+                    // Update to an operator output.
+                    // Propagate any changes forward along outgoing edges.
+                    Port::Source(port_index) => {
+                        let edges = &self.edges[location.node][port_index];
+                        self.implications
+                            .entry(location)
+                            .or_insert(MutableAntichain::new())
+                            .update_iter_and(Some((time, diff)), |time, diff| {
+                                pushed_changes.update((location, time.clone()), diff);
+                                for &new_target in edges.iter() {
+                                    worklist.push(Reverse((
+                                        time.clone(),
+                                        Location::from(new_target),
+                                        diff
+                                    )));
+                                }
+                            });
+                    },
+                };
             }
-
         }
     }
 
     /// A mutable reference to the pushed results of changes.
-    pub fn pushed(&mut self) -> &mut ChangeBatch<(Target, T)> {
+    pub fn pushed(&mut self) -> &mut ChangeBatch<(Location, T)> {
         &mut self.pushed_changes
     }
+
+    /// A reference to the minimal pointstamps in the scope.
+    pub fn global(&self) -> &HashSet<(Location, T)> {
+
+        // A pointstamp (location, timestamp) is in the global frontier exactly when:
+        //
+        //  1. `self.pointstamps[location]` has count[timestamp] > 0.
+        //  2. `self.implications[location]` has count[timestamp] == 1.
+        //
+        // Such a pointstamp would, if removed, cause a change to `self.implications`,
+        // which is what we track for per operator input frontiers. If the above do not
+        // hold, then its removal either 1. shouldn't be possible, or 2. will not affect
+        // the output of `self.implications`.
+        //
+        // As we grind through changes to `self.implications` we *should* be able to
+        // notice changes to the above properties. At least, we can notice as the counts
+        // for `self.implications` changes to and from 1.
+
+        // There are some monotonicity properties we could perhaps exploit. A pointstamp
+        // may have its `self.poinstamps` incremented to non-zero only when it is in
+        // advance of its `self.implications`, it may then enter the global frontier
+        // when this count goes to one, and it may then depart when its count goes to zero.
+        // A pointstamp cannot return to the global frontier once departed.
+
+        // Alternately, perhaps, we could just have a slighly more complicated test for
+        // "is in global frontier" where we just test these properties for stashed updates.
+        // We might need to re-check for many (all?) stashed updates, unless we can track
+        // which have potentially changed (which we can do, I think).
+
+        unimplemented!()
+    }
+
+    /// Indicates if pointstamp is in the scope-wide frontier.
+    ///
+    /// A pointstamp (location, timestamp) is in the global frontier exactly when:
+    ///
+    ///  1. `self.pointstamps[location]` has count[timestamp] > 0.
+    ///  2. `self.implications[location]` has count[timestamp] == 1.
+    ///
+    /// Such a pointstamp would, if removed from `self.pointstamps`, cause a change
+    /// to `self.implications`, which is what we track for per operator input frontiers.
+    /// If the above do not hold, then its removal either 1. shouldn't be possible,
+    /// or 2. will not affect the output of `self.implications`.
+    pub fn is_global(&self, location: Location, time: &T) -> bool {
+        self.pointstamps[&location].count_for(time) > 0 &&
+        self.implications[&location].count_for(time) == 1
+    }
+}
+
+/// Determines summaries from locations to scope outputs.
+///
+/// Specifically, for each location whose node identifier is non-zero, we compile
+/// the summaries along which they can reach each output.
+///
+/// Graph locations may be missing from the output, in which case they have no
+/// paths to scope outputs.
+fn summarize_outputs<T: Timestamp>(
+    nodes: &Vec<Vec<Vec<Antichain<T::Summary>>>>,
+    edges: &Vec<Vec<Vec<Target>>>,
+    ) -> HashMap<Location, Vec<Antichain<T::Summary>>>
+{
+    // A reverse edge map, to allow us to walk back up the dataflow graph.
+    let mut reverse = HashMap::new();
+    for (node, outputs) in edges.iter().enumerate() {
+        for (output, targets) in outputs.iter().enumerate() {
+            for target in targets.iter() {
+                reverse.insert(
+                    Location::from(*target),
+                    Location { node, port: Port::Source(output) }
+                );
+            }
+        }
+    }
+
+    let mut results = HashMap::new();
+    let mut worklist = VecDeque::<(Location, usize, T::Summary)>::new();
+
+    let outputs =
+    edges
+        .iter()
+        .flat_map(|x| x.iter())
+        .flat_map(|x| x.iter())
+        .filter(|target| target.index == 0);
+
+    // The scope may have no outputs, in which case we can do no work.
+    for output_target in outputs {
+        worklist.push_back((Location::from(*output_target), output_target.port, Default::default()));
+    }
+
+    // Loop until we stop discovering novel reachability paths.
+    while let Some((location, output, summary)) = worklist.pop_front() {
+
+        match location.port {
+
+            // This is an output port of an operator, or a scope input.
+            // We want to crawl up the operator, to its inputs.
+            Port::Source(output_port) => {
+
+                // Consider each input port of the associated operator.
+                for (input_port, summaries) in nodes[location.node].iter().enumerate() {
+
+                    // Determine the current path summaries from the input port.
+                    let location = Location { node: location.node, port: Port::Target(input_port) };
+                    let mut antichains = results.entry(location).or_insert(Vec::new());
+                    while antichains.len() <= output { antichains.push(Antichain::new()); }
+
+                    // Combine each operator-internal summary to the output with `summary`.
+                    for operator_summary in summaries[output_port].elements().iter() {
+                        if let Some(combined) = operator_summary.followed_by(&summary) {
+                            if antichains[output].insert(combined.clone()) {
+                                worklist.push_back((location, output, combined));
+                            }
+                        }
+                    }
+                }
+
+            },
+
+            // This is an input port of an operator, or a scope output.
+            // We want to walk back the edges leading to it.
+            Port::Target(_port) => {
+
+                // Each target should have (at most) one source.
+                if let Some(source) = reverse.get(&location) {
+                    let mut antichains = results.entry(*source).or_insert(Vec::new());
+                    while antichains.len() <= output { antichains.push(Antichain::new()); }
+
+                    if antichains[output].insert(summary.clone()) {
+                        worklist.push_back((*source, output, summary.clone()));
+                    }
+                }
+
+            },
+        }
+
+    }
+
+    // Discard summaries from the scope input.
+    results.retain(|key,_val| key.node != 0);
+    results
 }


### PR DESCRIPTION
This PR introduces a few light changes to reachability that may have horribly broken things.

The intent is mostly a refactoring, which attempts to make the progress logic a bit more clear. It is in preparation for a more extensive reworking in which progress tracking is demoted to a secondary thing that a dataflow scheduler does. As such, we are trying to make it as simple as possible here.

The main change that might be surprising is what I *think* is a bugfix: scopes previously reported outgoing messages as part of their "internal" capabilities, in addition to reporting them as outgoing messages. The capabilities were not released until the next time the scope was interacted with. This may have led to one-round latencies on progress information flowing out of scopes. But it is fixed now, and may or may not be problematic.