### PR TITLE
Operate rework [WIP]

### DIFF
--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -101,7 +101,8 @@ impl<G: Scope, D: Data> Probe<G, D> for Stream<G, D> {
 
         builder.build(
             move |changes| {
-                frontier.borrow_mut().update_iter(changes[0].drain());
+                let mut borrow = frontier.borrow_mut();
+                borrow.update_iter(changes[0].drain());
             },
             move |consumed, internal, produced| {
 

--- a/src/progress/nested/reachability.rs
+++ b/src/progress/nested/reachability.rs
@@ -393,7 +393,7 @@ impl<T:Timestamp> Tracker<T> {
     }
 
     ///
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_drained(&mut self) -> bool {
         self.pusheds.iter_mut().all(|x| x.iter_mut().all(|y| y.is_empty()))
     }
 
@@ -447,32 +447,32 @@ impl<T:Timestamp> Tracker<T> {
         for input in 0..self.targets[index].len() {
             let target_target = &self.target_target[index][input];
             let pusheds = &mut self.pusheds;
-            self.targets[index][input].update_iter_and(None, |time, value| {
+            for (time, diff) in self.targets[index][input].update_iter(None) {
                 for &(target, ref antichain) in target_target.iter() {
                     let pusheds = &mut pusheds[target.index][target.port];
                     for summary in antichain.elements().iter() {
-                        if let Some(new_time) = summary.results_in(time) {
-                            pusheds.update(new_time, value);
+                        if let Some(new_time) = summary.results_in(&time) {
+                            pusheds.update(new_time, diff);
                         }
                     }
                 }
-            });
+            }
         }
 
         // Propagate changes at each output (source).
         for output in 0..self.sources[index].len() {
             let source_target = &self.source_target[index][output];
             let pusheds = &mut self.pusheds;
-            self.sources[index][output].update_iter_and(None, |time, value| {
+            for (time, diff) in self.sources[index][output].update_iter(None) {
                 for &(target, ref antichain) in source_target.iter() {
                     let pusheds = &mut pusheds[target.index][target.port];
                     for summary in antichain.elements().iter() {
-                        if let Some(new_time) = summary.results_in(time) {
-                            pusheds.update(new_time, value);
+                        if let Some(new_time) = summary.results_in(&time) {
+                            pusheds.update(new_time, diff);
                         }
                     }
                 }
-            });
+            }
         }
     }
 

--- a/src/progress/operate.rs
+++ b/src/progress/operate.rs
@@ -1,9 +1,9 @@
 //! Methods which describe an operators topology, and the progress it makes.
 
-use std::default::Default;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 use progress::{Timestamp, ChangeBatch, Antichain};
-
 
 /// Methods for describing an operators topology, and the progress it makes.
 pub trait Operate<T: Timestamp> {
@@ -32,6 +32,12 @@ pub trait Operate<T: Timestamp> {
     /// The number of outputs.
     fn outputs(&self) -> usize;
 
+    /// A descriptive name for the operator
+    fn name(&self) -> String;
+
+    /// Schedules the operator.
+    fn schedule(&mut self) -> bool;
+
     /// Fetches summary information about internal structure of the operator.
     ///
     /// Each operator must summarize its internal structure by a map from pairs `(input, output)`
@@ -43,59 +49,35 @@ pub trait Operate<T: Timestamp> {
     ///
     /// The default behavior is to indicate that timestamps on any input can emerge unchanged on
     /// any output, and no initial capabilities are held.
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Vec<ChangeBatch<T>>) {
-        (vec![vec![Antichain::from_elem(Default::default()); self.outputs()]; self.inputs()],
-         vec![ChangeBatch::new(); self.outputs()])
-    }
+    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Rc<RefCell<SharedProgress<T>>>);
 
-    /// Presents summary information about the external structure around the operator.
-    ///
-    /// Each operator exists in the context of a parent scope, and the edges and other operators it
-    /// hosts represent paths messages may take from this operators outputs back to its inputs. For
-    /// an operator to correctly understand the implications of local progress statements, it must
-    /// understand how messages it produces may eventually return to its inputs.
-    ///
-    /// The parent scope must also provide initial capabilities for each of the inputs, reflecting
-    /// work elsewhere in the timely computation. Note: it is not clear whether the parent must not
-    /// include capabilities expressed by the operator itself. It seems possible to exclude such
-    /// capabilities, if it would help the operator, but the operator should not yet rely on any
-    /// specific behavior.
-    fn set_external_summary(&mut self, _summaries: Vec<Vec<Antichain<T::Summary>>>, _frontier: &mut [ChangeBatch<T>]) { }
-
-    /// Reports a summary of progress statements external to the operator and its peer group.
-    ///
-    /// This report summarizes *all* of the external world, including updates issued by the operator
-    /// itself. This is important, and means that there is an ordering constraint that needs to be
-    /// enforced by the operator: before reporting any summarized progress to its parent, a child
-    /// must install the non-summarized parts (internal messages, capabilities) locally. Otherwise,
-    /// the child may learn about external "progress" corresponding to its own actions, and without
-    /// noting the consequences of those actions, will be in a bit of a pickle.
-    ///
-    /// Note: Callee is expected to consume the contents of _external to indicate acknowledgement.
-    fn push_external_progress(&mut self, external: &mut [ChangeBatch<T>]) {
-        // default implementation just drains the external updates
-        for updates in external.iter_mut() {
-            updates.clear();
-        }
-    }
-
-    /// Retrieves a summary of progress statements internal to the operator.
-    ///
-    /// Returns a bool indicating if there is any unreported work remaining (e.g. work that doesn't
-    /// project on an output).
-    ///
-    /// Note: not "internal to the operator and its peer group". The operator instance should only
-    /// report progress performed by its own instance. The parent scope will figure out what to do
-    /// with this information (mostly likely exchange it with its peers). There does seem to be the
-    /// opportunity to optimize this, but it may complicate the life of the parent to know which of
-    /// its children are reporting partial information and which are complete.
-    fn pull_internal_progress(&mut self, consumed: &mut [ChangeBatch<T>],          // to populate
-                                         internal: &mut [ChangeBatch<T>],          // to populate
-                                         produced: &mut [ChangeBatch<T>]) -> bool; // to populate
-
-    /// A descriptive name for the operator
-    fn name(&self) -> String;
+    /// Signals that external frontiers have been set.
+    fn set_external_summary(&mut self) { }
 
     /// Indicates of whether the operator requires `push_external_progress` information or not.
     fn notify_me(&self) -> bool { true }
+}
+
+/// Progress information shared between parent and child.
+pub struct SharedProgress<T: Timestamp> {
+    /// Frontier capability changes reported by the parent scope.
+    pub frontiers: Vec<ChangeBatch<T>>,
+    /// Consumed message changes reported by the child operator.
+    pub consumeds: Vec<ChangeBatch<T>>,
+    /// Internal capability changes reported by the child operator.
+    pub internals: Vec<ChangeBatch<T>>,
+    /// Produced message changes reported by the child operator.
+    pub produceds: Vec<ChangeBatch<T>>,
+}
+
+impl<T: Timestamp> SharedProgress<T> {
+    /// Allocates a new shared progress structure.
+    pub fn new(inputs: usize, outputs: usize) -> Self {
+        SharedProgress {
+            frontiers: vec![ChangeBatch::new(); inputs],
+            consumeds: vec![ChangeBatch::new(); inputs],
+            internals: vec![ChangeBatch::new(); outputs],
+            produceds: vec![ChangeBatch::new(); outputs],
+        }
+    }
 }

--- a/src/progress/operate.rs
+++ b/src/progress/operate.rs
@@ -60,6 +60,11 @@ pub trait Operate<T: Timestamp> : Schedule {
     fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Rc<RefCell<SharedProgress<T>>>);
 
     /// Signals that external frontiers have been set.
+    ///
+    /// By default this method does nothing, and leaves all changes in the `frontiers` element
+    /// of the shared progress state. An operator should be able to consult `frontiers` at any
+    /// point and read out the current frontier information, or the changes from the last time
+    /// that `frontiers` was drained.
     fn set_external_summary(&mut self) { }
 
     /// Indicates of whether the operator requires `push_external_progress` information or not.

--- a/src/progress/operate.rs
+++ b/src/progress/operate.rs
@@ -5,8 +5,22 @@ use std::cell::RefCell;
 
 use progress::{Timestamp, ChangeBatch, Antichain};
 
+/// A type that can be scheduled.
+pub trait Schedule {
+
+    /// A descriptive name for the operator
+    fn name(&self) -> &str;
+
+    /// An address identifying the operator.
+    fn path(&self) -> &[usize];
+
+    /// Schedules the operator, with information about child requests.
+    fn schedule(&mut self) -> bool;
+
+}
+
 /// Methods for describing an operators topology, and the progress it makes.
-pub trait Operate<T: Timestamp> {
+pub trait Operate<T: Timestamp> : Schedule {
 
     /// Indicates if the operator is strictly local to this worker.
     ///
@@ -31,12 +45,6 @@ pub trait Operate<T: Timestamp> {
     fn inputs(&self) -> usize;
     /// The number of outputs.
     fn outputs(&self) -> usize;
-
-    /// A descriptive name for the operator
-    fn name(&self) -> String;
-
-    /// Schedules the operator.
-    fn schedule(&mut self) -> bool;
 
     /// Fetches summary information about internal structure of the operator.
     ///

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -143,7 +143,7 @@ impl<A: Allocate> Worker<A> {
         let mut operator = subscope.into_inner().build(self);
 
         operator.get_internal_summary();
-        operator.set_external_summary(Vec::new(), &mut []);
+        operator.set_external_summary();
 
         let wrapper = Wrapper {
             _index: dataflow_index,
@@ -194,7 +194,7 @@ struct Wrapper {
 
 impl Wrapper {
     fn step(&mut self) -> bool {
-        let active = self.operate.as_mut().map(|op| op.pull_internal_progress(&mut [], &mut [], &mut [])).unwrap_or(false);
+        let active = self.operate.as_mut().map(|op| op.schedule()).unwrap_or(false);
         if !active {
             self.operate = None;
             self.resources = None;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -6,7 +6,8 @@ use std::any::Any;
 use std::time::Instant;
 
 use progress::timestamp::{Refines};
-use progress::{Timestamp, Operate, SubgraphBuilder};
+use progress::{Timestamp, SubgraphBuilder};
+use progress::operate::{Schedule, Operate};
 use communication::{Allocate, Data, Push, Pull};
 use dataflow::scopes::Child;
 
@@ -188,7 +189,7 @@ impl<A: Allocate> Clone for Worker<A> {
 
 struct Wrapper {
     _index: usize,
-    operate: Option<Box<Operate<()>>>,
+    operate: Option<Box<Schedule>>,
     resources: Option<Box<Any>>,
 }
 


### PR DESCRIPTION
This is a work in progress PR for refactoring the `Operate` trait and various consequent refactorings that may spill out. Mainly this means over in `subgraph.rs` where things are getting much simpler and clearer (to my tastes).

The main change is the separation of `Operate` into two traits, one of which `Schedule` has a relatively simple and time-free interface:

```rust
/// A type that can be scheduled.
pub trait Schedule {
    /// A descriptive name for the operator
    fn name(&self) -> &str;
    /// An address identifying the operator.
    fn path(&self) -> &[usize];
    /// Schedules the operator, with information about child requests.
    fn schedule(&mut self) -> bool;
}
```

The other methods remain in `Operate<T: Timestamp>`. They are, however, much slimmer now, which is making things a fair bit more clear I believe.